### PR TITLE
Fix install version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow to run test in the build directory on Windows ([#630](https://github.com/coal-library/coal/pull/630))
 - Updated nix flake from `hpp-fcl` to `coal` ([#632](https://github.com/coal-library/coal/pull/632)
 - Fix hpp-fclConfig.cmake on Windows ([#633](https://github.com/coal-library/coal/pull/633))
+- Fix install version ([#651](https://github.com/coal-library/coal/pull/651))
 
 ### Added
 - Add Pixi support ([#629](https://github.com/coal-library/coal/pull/629))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -199,6 +199,7 @@ if(UNIX)
   get_relative_rpath(${CMAKE_INSTALL_LIBDIR} ${PROJECT_NAME}_INSTALL_RPATH)
   set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH "${${PROJECT_NAME}_INSTALL_RPATH}")
 endif()
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION})
 
 cxx_flags_by_compiler_frontend(
   MSVC "/bigobj"


### PR DESCRIPTION
This will install libcoal.so.3.0.0 and libcoal.so as a symlink, instead of just libcoal.so as a binary.