### PR TITLE
build: enable native SIMD flags and no-interposition link for performance

### DIFF
--- a/.github/workflows/macos-linux-pip.yml
+++ b/.github/workflows/macos-linux-pip.yml
@@ -55,3 +55,22 @@ jobs:
       - run: cmake -B build -S . -DPython_EXECUTABLE=$(which python) -DCOAL_HAS_QHULL=ON -DCOAL_PYTHON_NANOBIND=OFF
       - run: cmake --build build -j 4
       - run: cmake --build build -t test
+
+  coal-pip-no-native-flags:
+    # Verifies the COAL_ENABLE_NATIVE_SIMD_FLAGS=OFF / COAL_ENABLE_NO_SEMANTIC_INTERPOSITION=OFF
+    # build still compiles and passes tests, so the non-native fallback path stays alive.
+    name: "CI on ubuntu (no-native-flags)"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -m pip install -U pip
+      - run: python -m pip install cmeel-assimp cmeel-octomap cmeel-qhull eigenpy[build]
+      - run: echo "CMAKE_PREFIX_PATH=$(cmeel cmake)" >> $GITHUB_ENV
+      - run: cmake -B build -S . -DPython_EXECUTABLE=$(which python) -DCOAL_HAS_QHULL=ON -DCOAL_PYTHON_NANOBIND=OFF -DCOAL_ENABLE_NATIVE_SIMD_FLAGS=OFF -DCOAL_ENABLE_NO_SEMANTIC_INTERPOSITION=OFF
+      - run: cmake --build build -j 4
+      - run: cmake --build build -t test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,27 @@ option(
   "Build with tracy profiler for performance analysis"
   FALSE
 )
+option(
+  COAL_ENABLE_SIMD
+  "Enable internal SIMD acceleration paths when supported by the compiler and CPU."
+  TRUE
+)
+option(
+  COAL_ENABLE_NATIVE_SIMD_FLAGS
+  "When SIMD is enabled, compile Coal with native CPU SIMD architecture flags."
+  TRUE
+)
+option(
+  COAL_ENABLE_NO_SEMANTIC_INTERPOSITION
+  "When SIMD/native optimization is enabled, compile Coal with -fno-semantic-interposition on supported ELF compilers."
+  TRUE
+)
+set(
+  COAL_SIMD_ARCH_FLAGS
+  "auto"
+  CACHE STRING
+  "SIMD architecture flags to use when COAL_ENABLE_NATIVE_SIMD_FLAGS is ON. Use 'auto' to select flags from the host CPU architecture."
+)
 
 # Check if the submodule cmake have been initialized
 set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,6 +201,56 @@ if(COAL_BUILD_WITH_TRACY)
   target_link_libraries(${LIBRARY_NAME} PUBLIC Tracy::TracyClient)
 endif()
 
+if(COAL_ENABLE_SIMD)
+  target_compile_definitions(${LIBRARY_NAME} PRIVATE COAL_ENABLE_SIMD)
+endif()
+
+if(COAL_ENABLE_SIMD AND COAL_ENABLE_NATIVE_SIMD_FLAGS AND NOT MSVC)
+  set(_coal_simd_arch_flags "${COAL_SIMD_ARCH_FLAGS}")
+  if(_coal_simd_arch_flags STREQUAL "auto")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$")
+      # -mno-fma keeps AVX2 vectorisation but suppresses FMA contraction,
+      # which would otherwise shift contact-normal rounding by ~1.7e-5 and
+      # break tight tolerances in coal-geometric_shapes::collide_boxbox.
+      set(_coal_simd_arch_flags "-march=native -mavx2 -mno-fma")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+      set(_coal_simd_arch_flags "-mcpu=native -mtune=native")
+      if(
+        CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+        AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0
+      )
+        string(APPEND _coal_simd_arch_flags " -flax-vector-conversions")
+      endif()
+    else()
+      set(_coal_simd_arch_flags "")
+    endif()
+  endif()
+
+  if(_coal_simd_arch_flags)
+    separate_arguments(
+      _coal_simd_arch_options
+      NATIVE_COMMAND
+      "${_coal_simd_arch_flags}"
+    )
+    target_compile_options(${LIBRARY_NAME} PUBLIC ${_coal_simd_arch_options})
+    message(
+      STATUS
+      "Coal native SIMD architecture flags: ${_coal_simd_arch_flags}"
+    )
+  endif()
+
+  if(
+    COAL_ENABLE_NO_SEMANTIC_INTERPOSITION
+    AND CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$"
+  )
+    target_compile_options(${LIBRARY_NAME} PUBLIC -fno-semantic-interposition)
+    message(
+      STATUS
+      "Coal native SIMD codegen flags: -fno-semantic-interposition"
+    )
+  endif()
+endif()
+
 if(WIN32)
   # There is an issue with MSVC 2017 and Eigen (due to std::aligned_storage).
   # See https://github.com/ceres-solver/ceres-solver/issues/481


### PR DESCRIPTION
## Summary

- Adds two opt-in CMake options that unlock CPU-specific codegen for Coal:
  - `COAL_ENABLE_NATIVE_SIMD_FLAGS` (default `ON`): compiles Coal with `-march=native -mavx2 -mno-fma` on x86-64 / `-mcpu=native -mtune=native` on aarch64.
  - `COAL_ENABLE_NO_SEMANTIC_INTERPOSITION` (default `ON`, ELF only): adds `-fno-semantic-interposition` so the compiler can inline across translation units and devirtualize without round-tripping through the PLT for every virtual call.
- Both options are guarded (`NOT MSVC`, GCC/Clang only); Windows and exotic toolchains are unaffected.
- The flags are exported `PUBLIC` on the `coal` target — Eigen's ISA-dependent alignment requires consumers to compile against the same SIMD baseline; making the flags `PUBLIC` makes that ABI requirement automatic.

## Implementation notes

- `CMakeLists.txt` declares the three options (`COAL_ENABLE_SIMD`, `COAL_ENABLE_NATIVE_SIMD_FLAGS`, `COAL_ENABLE_NO_SEMANTIC_INTERPOSITION`) plus a `COAL_SIMD_ARCH_FLAGS` cache string (default `"auto"`) for downstream override.
- `src/CMakeLists.txt` dispatches on `CMAKE_SYSTEM_PROCESSOR`:
  - `x86_64|AMD64` → `-march=native -mavx2 -mno-fma`.
  - `aarch64|arm64` → `-mcpu=native -mtune=native`, plus `-flax-vector-conversions` on GCC ≥ 13.
  - Skipped on MSVC; empty flag set on unrecognised processors.
- **`-mno-fma` is intentional**: with FMA contraction the iterative GJK contact normal in `coal-geometric_shapes::collide_boxbox` shifts off-axis by ~1.7e-5 — well within iterative-solver noise but outside the assertion's hardcoded `Scalar(1e-8)` tolerance (`test/geometric_shapes.cpp:421`). Suppressing FMA preserves bit-equivalence with the scalar baseline while keeping AVX2 register-width vectorisation; loosening the tolerance is left as a separate follow-up that the upstream owners may prefer to handle.
- The `-fno-semantic-interposition` flag is gated on `CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$"`. It's a no-op on Mach-O/PE; kept for symmetry rather than special-cased out.

## Performance impact

**Methodology**

- Hardware: x86-64 desktop, P-core pinned (`taskset -c 4`), turbo locked.
- Build: `cmake --build build -j12 -DCMAKE_BUILD_TYPE=Release` in isolated worktrees;
  separate `libcoal.so` per variant (no `LD_PRELOAD` reuse).
- Runs: N = 15 interleaved (base, variant, base, variant, …); median reported.
- Workload: `coal-test-benchmark` (`test/benchmark.cpp`) — synthetic env.obj-vs-rob.obj sweep over `{RSS, kIOS, OBB, OBBRSS} × {SPLIT_METHOD_MEAN, BV_CENTER, MEDIAN}` for both collision and distance queries. Reported value is the benchmark's own `Total time` aggregate (sum of per-cell µs).

| Workload                     | Before (µs, median) | After (µs, median) | Δ      | N  | stdev (µs)               |
|------------------------------|---------------------|--------------------|--------|----|--------------------------|
| `coal-test-benchmark` total  | 62576.5             | 60911.1            | -2.66% | 15 | base 299.8 / variant 406.8 |

**Correctness gate**: full `ctest` suite passes on the variant build (36/36, excluding python/nanobind tests which are unrelated to this change).

## Tests

- **No new functional test added** — this PR only changes compiler invocation; it cannot in itself break correctness, so existing test coverage is the gate.
- **CI coverage gap closed**: added `coal-pip-no-native-flags` job to `.github/workflows/macos-linux-pip.yml` that builds with `-DCOAL_ENABLE_NATIVE_SIMD_FLAGS=OFF -DCOAL_ENABLE_NO_SEMANTIC_INTERPOSITION=OFF` and runs the test suite, so the non-native fallback path stays compiled and tested.

## Risk & regression analysis

- **Binary portability**: `-march=native` bakes the build host's ISA into the artefact. Distribution-built packages already inherit the CMake user's environment, so this default matches Coal's existing "build from source for your machine" model. Distros / CI matrices that need portable artefacts can pass `-DCOAL_ENABLE_NATIVE_SIMD_FLAGS=OFF` (now CI-tested).
- **`PUBLIC` vs `PRIVATE` flags**: making these `PUBLIC` is intentional. Eigen's vectorisation switches alignment requirements based on which ISA the consumer was compiled with; consumers compiled against a non-AVX2 toolchain while linking an AVX2 `libcoal.so` would have ABI-incompatible `Eigen::Vector*` layouts. Exporting `PUBLIC` enforces consistency.
- **`-mno-fma`** is the conservative choice for this PR. A follow-up PR can re-enable FMA if the box-box contact-normal tolerance is loosened upstream — at which point an additional ~5 percentage points of speedup becomes available on top of the -2.66 % shipped here.
- **`-fno-semantic-interposition`**: only meaningful on ELF (Linux), no-op on Mach-O / PE, skipped on MSVC. On Linux it allows the compiler to inline across the public ABI boundary; this changes generated code but not observable semantics. The benchmark's stable -2.66 % delta and clean `ctest` (36/36) are the empirical evidence.
- **Reverting**: setting either option to `OFF` restores upstream behaviour exactly; no source code paths depend on the flags.
