### PR TITLE
Print collision data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - handle the specific cases of n_desired = 1 or 2 ([805](https://github.com/coal-library/coal/pull/805))
   - improve efficiency of ContactPatchSimplifierMaxArea and improve testing of patch simplifiers ([813](https://github.com/coal-library/coal/pull/813))
 - timings: + and += operators ([805](https://github.com/coal-library/coal/pull/805))
+- Add print methods for collision data (`Contact`, `CollisionRequest`, `CollisionResult`, `DistanceRequest`, `DistanceResult`, `ContactPatch`, `ContactPatchRequest` and `ContactPatchResult`) ([854](https://github.com/coal-library/coal/pull/854)).
+  - One can now do `std::cout << contact` for example.
+  - Added the `PrintableVisitor` in python bindings so that `print(contact)` works in python as well
 
 ### Removed
 - Remove direct dependency to ([#744](https://github.com/coal-library/coal/pull/744)):

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -1061,16 +1061,26 @@ struct COAL_DLLAPI ContactPatchResult {
   size_t numContactPatches() const { return this->m_contact_patches.size(); }
 
   /// @brief Returns a new unused contact patch from the internal data vector.
-  ContactPatchRef getUnusedContactPatch() {
+  ContactPatch& getUnusedContactPatch() {
     if (this->m_id_available_patch >= this->m_contact_patches_data.size()) {
       COAL_LOG_WARNING(
           "Trying to get an unused contact patch but all contact patches are "
           "used. Increasing size of contact patches vector, at the cost of a "
           "copy. You should increase `max_num_patch` in the "
-          "`ContactPatchRequest`.");
-      this->m_contact_patches_data.emplace_back(
-          this->m_contact_patches_data.back());
-      this->m_contact_patches_data.back().clear();
+          "`ContactPatchRequest` when setting up `ContactPatchResult`.");
+      bool need_to_reset_references = (this->m_contact_patches_data.size() ==
+                                       this->m_contact_patches_data.capacity());
+
+      this->m_contact_patches_data.emplace_back(ContactPatch());
+
+      if (need_to_reset_references) {
+        // If we have reached the capacity of the data vector, all references
+        // in `m_contact_patches` are invalidated. We need to reset them.
+        this->m_contact_patches.clear();
+        for (size_t i = 0; i < this->m_id_available_patch; ++i) {
+          this->m_contact_patches.emplace_back(this->m_contact_patches_data[i]);
+        }
+      }
     }
     ContactPatch& contact_patch =
         this->m_contact_patches_data[this->m_id_available_patch];

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -299,6 +299,11 @@ struct COAL_DLLAPI QueryRequest {
     COAL_COMPILER_DIAGNOSTIC_POP
   }
 
+  /// @brief whether two QueryRequest are different or not
+  inline bool operator!=(const QueryRequest& other) const {
+    return !(*this == other);
+  }
+
   /// @brief Prints the query request to the provided output stream.
   void disp(std::ostream& os, const std::string& prefix = "") const {
     using namespace std;
@@ -447,6 +452,11 @@ struct COAL_DLLAPI CollisionRequest : QueryRequest {
     COAL_COMPILER_DIAGNOSTIC_POP
   }
 
+  /// @brief whether two CollisionRequest are different or not
+  inline bool operator!=(const CollisionRequest& other) const {
+    return !(*this == other);
+  }
+
   /// @brief Prints the collision request to the provided output stream.
   void disp(std::ostream& os, const std::string& prefix = "") const {
     using namespace std;
@@ -523,6 +533,11 @@ struct COAL_DLLAPI CollisionResult : QueryResult {
            nearest_points[0] == other.nearest_points[0] &&
            nearest_points[1] == other.nearest_points[1] &&
            normal == other.normal;
+  }
+
+  /// @brief whether two CollisionResult are the same or not
+  bool operator!=(const CollisionResult& other) const {
+    return !(*this == other);
   }
 
   /// @brief return binary collision result
@@ -787,6 +802,9 @@ struct COAL_DLLAPI ContactPatch {
            this->points() == other.points();
   }
 
+  /// @brief Whether two contact patches are different or not.
+  bool operator!=(const ContactPatch& other) const { return !(*this == other); }
+
   /// @brief Whether two contact patches are the same or not.
   /// Checks for different order of the points.
   bool isSame(
@@ -977,6 +995,11 @@ struct COAL_DLLAPI ContactPatchRequest {
            this->getPatchTolerance() == other.getPatchTolerance();
   }
 
+  /// @brief Whether two ContactPatchRequest are different or not.
+  bool operator!=(const ContactPatchRequest& other) const {
+    return !(*this == other);
+  }
+
   /// @brief Prints the contact patch request to the provided output stream.
   void disp(std::ostream& os, const std::string& prefix = "") const {
     using namespace std;
@@ -1140,6 +1163,11 @@ struct COAL_DLLAPI ContactPatchResult {
     return true;
   }
 
+  /// @brief Whether two ContactPatchResult are different or not.
+  bool operator!=(const ContactPatchResult& other) const {
+    return !(*this == other);
+  }
+
   /// @brief Repositions the ContactPatch when they get inverted during their
   /// construction.
   void swapObjects() {
@@ -1248,6 +1276,11 @@ struct COAL_DLLAPI DistanceRequest : QueryRequest {
            enable_signed_distance == other.enable_signed_distance &&
            rel_err == other.rel_err && abs_err == other.abs_err;
     COAL_COMPILER_DIAGNOSTIC_POP
+  }
+
+  /// @brief whether two DistanceRequest are different or not
+  inline bool operator!=(const DistanceRequest& other) const {
+    return !(*this == other);
   }
 
   /// @brief Prints the distance request to the provided output stream.

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -51,6 +51,7 @@
 #include "coal/timings.h"
 #include "coal/narrowphase/narrowphase_defaults.h"
 #include "coal/logging.h"
+#include "coal/collision_utility.h"
 
 namespace coal {
 
@@ -162,6 +163,34 @@ struct COAL_DLLAPI Contact {
   bool operator!=(const Contact& other) const { return !(*this == other); }
 
   Scalar getDistanceToCollision(const CollisionRequest& request) const;
+
+  /// \brief Prints the contact to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    os << prefix
+       << "  o1 type: " << (o1 ? get_node_type_name(o1->getNodeType()) : "null")
+       << ",\n";
+    os << prefix
+       << "  o2 type: " << (o2 ? get_node_type_name(o2->getNodeType()) : "null")
+       << ",\n";
+    os << prefix << "  b1: " << b1 << ",\n";
+    os << prefix << "  b2: " << b2 << ",\n";
+    os << prefix << "  normal: " << normal.transpose() << ",\n";
+    os << prefix << "  nearest_points[0]: " << nearest_points[0].transpose()
+       << ",\n";
+    os << prefix << "  nearest_points[1]: " << nearest_points[1].transpose()
+       << ",\n";
+    os << prefix << "  pos: " << pos.transpose() << ",\n";
+    os << prefix << "  penetration_depth: " << penetration_depth << ",\n";
+  }
+
+  /// \copydoc disp
+  friend std::ostream& operator<<(std::ostream& os, const Contact& contact) {
+    os << "Contact: {" << "\n";
+    contact.disp(os);
+    os << "}" << "\n";
+    return os;
+  }
 };
 
 struct QueryResult;
@@ -269,6 +298,34 @@ struct COAL_DLLAPI QueryRequest {
            collision_distance_threshold == other.collision_distance_threshold;
     COAL_COMPILER_DIAGNOSTIC_POP
   }
+
+  /// @brief Prints the query request to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    os << prefix << "  gjk_initial_guess: "
+       << (gjk_initial_guess == GJKInitialGuess::DefaultGuess
+               ? "DefaultGuess"
+               : (GJKInitialGuess::CachedGuess ? "CachedGuess"
+                                               : "BoundingVolumeGuess"))
+       << ",\n";
+    os << prefix << "  cached_gjk_guess: " << cached_gjk_guess.transpose()
+       << ",\n";
+    os << prefix << "  cached_support_func_guess: "
+       << cached_support_func_guess.transpose() << ",\n";
+    os << prefix << "  gjk_max_iterations: " << gjk_max_iterations << ",\n";
+    os << prefix << "  gjk_tolerance: " << gjk_tolerance << ",\n";
+    os << prefix << "  gjk_variant: " << static_cast<int>(gjk_variant) << ",\n";
+    os << prefix << "  gjk_convergence_criterion: "
+       << static_cast<int>(gjk_convergence_criterion) << ",\n";
+    os << prefix << "  gjk_convergence_criterion_type: "
+       << static_cast<int>(gjk_convergence_criterion_type) << ",\n";
+    os << prefix << "  epa_max_iterations: " << epa_max_iterations << ",\n";
+    os << prefix << "  epa_tolerance: " << epa_tolerance << ",\n";
+    os << prefix << "  enable_timings: " << enable_timings << ",\n";
+    os << prefix
+       << "  collision_distance_threshold: " << collision_distance_threshold
+       << ",\n";
+  }
 };
 
 /// @brief base class for all query results
@@ -285,6 +342,16 @@ struct COAL_DLLAPI QueryResult {
   QueryResult()
       : cached_gjk_guess(Vec3s::Zero()),
         cached_support_func_guess(support_func_guess_t::Constant(-1)) {}
+
+  /// @brief Prints the query result to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    os << prefix << "  cached_gjk_guess: " << cached_gjk_guess.transpose()
+       << ",\n";
+    os << prefix << "  cached_support_func_guess: "
+       << cached_support_func_guess.transpose() << ",\n";
+    os << prefix << "  timings: " << timings.user << ",\n";
+  }
 };
 
 inline void QueryRequest::updateGuess(const QueryResult& result) const {
@@ -378,6 +445,26 @@ struct COAL_DLLAPI CollisionRequest : QueryRequest {
            break_distance == other.break_distance &&
            distance_upper_bound == other.distance_upper_bound;
     COAL_COMPILER_DIAGNOSTIC_POP
+  }
+
+  /// @brief Prints the collision request to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    QueryRequest::disp(os, prefix);
+    os << prefix << "  num_max_contacts: " << num_max_contacts << ",\n";
+    os << prefix << "  enable_contact: " << enable_contact << ",\n";
+    os << prefix << "  security_margin: " << security_margin << ",\n";
+    os << prefix << "  break_distance: " << break_distance << ",\n";
+    os << prefix << "  distance_upper_bound: " << distance_upper_bound << ",\n";
+  }
+
+  /// \copydoc disp
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const CollisionRequest& request) {
+    os << "CollisionRequest: {" << "\n";
+    request.disp(os);
+    os << "}" << "\n";
+    return os;
   }
 };
 
@@ -490,6 +577,35 @@ struct COAL_DLLAPI CollisionResult : QueryResult {
   /// @brief reposition Contact objects when fcl inverts them
   /// during their construction.
   void swapObjects();
+
+  /// \brief Prints the result to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    QueryResult::disp(os, prefix);
+    os << prefix << "  distance_lower_bound: " << distance_lower_bound << ",\n";
+    os << prefix << "  normal: " << normal.transpose() << ",\n";
+    os << prefix << "  nearest_points[0]: " << nearest_points[0].transpose()
+       << ",\n";
+    os << prefix << "  nearest_points[1]: " << nearest_points[1].transpose()
+       << ",\n";
+    os << prefix << "  contacts: {" << "\n";
+    for (std::size_t i = 0; i < contacts.size(); ++i) {
+      os << prefix << "    Contact " << i << ": {" << "\n";
+      const Contact& contact = contacts[i];
+      contact.disp(os, prefix + "      ");
+      os << prefix << "    }\n";
+    }
+    os << prefix << "  }\n";
+  }
+
+  /// \copydoc disp
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const CollisionResult& res) {
+    os << "CollisionResult:" << "\n";
+    res.disp(os);
+    os << "}" << "\n";
+    return os;
+  }
 };
 
 /// @brief This structure allows to encode contact patches.
@@ -712,6 +828,32 @@ struct COAL_DLLAPI ContactPatch {
 
     return true;
   }
+
+  /// @brief Prints the contact patch to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    os << prefix << "  tf: {" << "\n";
+    tf.disp(os, prefix + "    ");
+    os << prefix << "  },\n";
+    os << prefix << "  direction: "
+       << (direction == PatchDirection::DEFAULT ? "DEFAULT" : "INVERTED")
+       << ",\n";
+    os << prefix << "  penetration_depth: " << penetration_depth << ",\n";
+    os << prefix << "  points: {" << "\n";
+    for (size_t i = 0; i < this->size(); ++i) {
+      os << prefix << "    Point " << i << ": " << this->getPoint(i).transpose()
+         << ",\n";
+    }
+    os << prefix << "  }\n";
+  }
+
+  /// \copydoc disp
+  friend std::ostream& operator<<(std::ostream& os, const ContactPatch& patch) {
+    os << "ContactPatch: {" << "\n";
+    patch.disp(os);
+    os << "}" << "\n";
+    return os;
+  }
 };
 
 /// @brief Construct a frame from a `Contact`'s position and normal.
@@ -833,6 +975,25 @@ struct COAL_DLLAPI ContactPatchRequest {
            this->getNumSamplesCurvedShapes() ==
                other.getNumSamplesCurvedShapes() &&
            this->getPatchTolerance() == other.getPatchTolerance();
+  }
+
+  /// @brief Prints the contact patch request to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    os << prefix << "  max_num_patch: " << max_num_patch << ",\n";
+    os << prefix
+       << "  num_samples_curved_shapes: " << getNumSamplesCurvedShapes()
+       << ",\n";
+    os << prefix << "  patch_tolerance: " << getPatchTolerance() << ",\n";
+  }
+
+  /// \copydoc disp
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const ContactPatchRequest& request) {
+    os << "ContactPatchRequest: {" << "\n";
+    request.disp(os);
+    os << "}" << "\n";
+    return os;
   }
 };
 
@@ -995,6 +1156,30 @@ struct COAL_DLLAPI ContactPatchResult {
       }
     }
   }
+
+  /// @brief Prints the contact patch result to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    os << prefix << "  numContactPatches: " << this->numContactPatches()
+       << ",\n";
+    os << prefix << "  contact_patches: {" << "\n";
+    for (size_t i = 0; i < this->numContactPatches(); ++i) {
+      os << prefix << "  ContactPatch " << i << ": {" << "\n";
+      const ContactPatch& patch = this->getContactPatch(i);
+      patch.disp(os, prefix + "    ");
+      os << prefix << "  }\n";
+    }
+    os << prefix << "  }\n";
+  }
+
+  /// \copydoc disp
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const ContactPatchResult& result) {
+    os << "ContactPatchResult: {" << "\n";
+    result.disp(os);
+    os << "}" << "\n";
+    return os;
+  }
 };
 
 struct DistanceResult;
@@ -1063,6 +1248,25 @@ struct COAL_DLLAPI DistanceRequest : QueryRequest {
            enable_signed_distance == other.enable_signed_distance &&
            rel_err == other.rel_err && abs_err == other.abs_err;
     COAL_COMPILER_DIAGNOSTIC_POP
+  }
+
+  /// @brief Prints the distance request to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    QueryRequest::disp(os, prefix);
+    os << prefix << "  enable_signed_distance: " << enable_signed_distance
+       << ",\n";
+    os << prefix << "  rel_err: " << rel_err << ",\n";
+    os << prefix << "  abs_err: " << abs_err << ",\n";
+  }
+
+  /// \copydoc disp
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const DistanceRequest& request) {
+    os << "DistanceRequest: {" << "\n";
+    request.disp(os);
+    os << "}" << "\n";
+    return os;
   }
 };
 
@@ -1184,6 +1388,40 @@ struct COAL_DLLAPI DistanceResult : QueryResult {
     //    *other.o2;
 
     return is_same;
+  }
+
+  /// @brief whether two DistanceResult are different or not
+  inline bool operator!=(const DistanceResult& other) const {
+    return !(*this == other);
+  }
+
+  /// @brief Prints the distance result to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    QueryResult::disp(os, prefix);
+    os << prefix
+       << "  o1: " << (o1 ? get_node_type_name(o1->getNodeType()) : "null")
+       << ",\n";
+    os << prefix
+       << "  o2: " << (o2 ? get_node_type_name(o2->getNodeType()) : "null")
+       << ",\n";
+    os << prefix << "  b1: " << b1 << ",\n";
+    os << prefix << "  b2: " << b2 << ",\n";
+    os << prefix << "  min_distance: " << min_distance << ",\n";
+    os << prefix << "  normal: " << normal.transpose() << ",\n";
+    os << prefix << "  nearest_points[0]: " << nearest_points[0].transpose()
+       << ",\n";
+    os << prefix << "  nearest_points[1]: " << nearest_points[1].transpose()
+       << ",\n";
+  }
+
+  /// \copydoc disp
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const DistanceResult& result) {
+    os << "DistanceResult: {" << "\n";
+    result.disp(os);
+    os << "}" << "\n";
+    return os;
   }
 };
 

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -1057,6 +1057,40 @@ struct COAL_DLLAPI ContactPatchResult {
     this->set(request);
   };
 
+  /// @brief Copy constructor.
+  ContactPatchResult(const ContactPatchResult& other) { *this = other; }
+
+  /// @brief Move constructor.
+  ContactPatchResult(ContactPatchResult&& other) noexcept {
+    *this = std::move(other);
+  }
+
+  /// @brief Copy assignment operator.
+  ContactPatchResult& operator=(const ContactPatchResult& other) {
+    if (this != &other) {
+      this->m_contact_patches_data = other.m_contact_patches_data;
+      this->m_id_available_patch = other.m_id_available_patch;
+      this->m_contact_patches.clear();
+      for (size_t i = 0; i < this->m_id_available_patch; ++i) {
+        this->m_contact_patches.emplace_back(this->m_contact_patches_data[i]);
+      }
+    }
+    return *this;
+  }
+
+  /// @brief Move assignment operator.
+  ContactPatchResult& operator=(ContactPatchResult&& other) noexcept {
+    if (this != &other) {
+      this->m_contact_patches_data = std::move(other.m_contact_patches_data);
+      this->m_id_available_patch = other.m_id_available_patch;
+      this->m_contact_patches.clear();
+      for (size_t i = 0; i < this->m_id_available_patch; ++i) {
+        this->m_contact_patches.emplace_back(this->m_contact_patches_data[i]);
+      }
+    }
+    return *this;
+  }
+
   /// @brief Number of contact patches in the result.
   size_t numContactPatches() const { return this->m_contact_patches.size(); }
 

--- a/include/coal/math/transform.h
+++ b/include/coal/math/transform.h
@@ -233,10 +233,8 @@ class COAL_DLLAPI Transform3s {
     const Eigen::IOFormat vfmt =
         Eigen::IOFormat(Eigen::StreamPrecision, Eigen::DontAlignCols, ", ",
                         ", ", "", "", "[", "]");
-    // clang-format off
     os << prefix << "  Rotation:\n" << R.format(mfmt) << ",\n";
     os << prefix << "  Translation: " << T.format(vfmt) << ",\n";
-    // clang-format on
   }
 
   /// \copydoc disp

--- a/include/coal/math/transform.h
+++ b/include/coal/math/transform.h
@@ -221,12 +221,21 @@ class COAL_DLLAPI Transform3s {
   /// @brief Prints the transform to the provided output stream.
   void disp(std::ostream& os, const std::string& prefix = "") const {
     using namespace std;
+    // formatting for matrix
+    const Eigen::IOFormat mfmt =
+        Eigen::IOFormat(Eigen::StreamPrecision, !Eigen::DontAlignCols,
+                        ", ",                     // coeff separator
+                        ",\n" + prefix + "    ",  // row separator
+                        "[", "]",                 // row prefix and suffix
+                        prefix + "    [", "]"     // matrix prefix and suffix
+        );
+    // formatting for vector
+    const Eigen::IOFormat vfmt =
+        Eigen::IOFormat(Eigen::StreamPrecision, Eigen::DontAlignCols, ", ",
+                        ", ", "", "", "[", "]");
     // clang-format off
-    os << prefix << "  Rotation:\n";
-    os << prefix << "    " << R(0, 0) << " " << R(0, 1) << " " << R(0, 2) << "\n";
-    os << prefix << "    " << R(1, 0) << " " << R(1, 1) << " " << R(1, 2) << "\n";
-    os << prefix << "    " << R(2, 0) << " " << R(2, 1) << " " << R(2, 2) << ",\n";
-    os << prefix << "  Translation: " << T.transpose() << "\n";
+    os << prefix << "  Rotation:\n" << R.format(mfmt) << ",\n";
+    os << prefix << "  Translation: " << T.format(vfmt) << ",\n";
     // clang-format on
   }
 

--- a/include/coal/math/transform.h
+++ b/include/coal/math/transform.h
@@ -216,6 +216,26 @@ class COAL_DLLAPI Transform3s {
 
   bool operator!=(const Transform3s& other) const { return !(*this == other); }
 
+  /// @brief Prints the transform to the provided output stream.
+  void disp(std::ostream& os, const std::string& prefix = "") const {
+    using namespace std;
+    // clang-format off
+    os << prefix << "  Rotation:\n";
+    os << prefix << "    " << R(0, 0) << " " << R(0, 1) << " " << R(0, 2) << "\n";
+    os << prefix << "    " << R(1, 0) << " " << R(1, 1) << " " << R(1, 2) << "\n";
+    os << prefix << "    " << R(2, 0) << " " << R(2, 1) << " " << R(2, 2) << ",\n";
+    os << prefix << "  Translation: " << T.transpose() << "\n";
+    // clang-format on
+  }
+
+  /// \copydoc disp
+  friend std::ostream& operator<<(std::ostream& os, const Transform3s& tf) {
+    os << "Transform3s: {" << "\n";
+    tf.disp(os);
+    os << "}" << "\n";
+    return os;
+  }
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 

--- a/include/coal/math/transform.h
+++ b/include/coal/math/transform.h
@@ -210,10 +210,12 @@ class COAL_DLLAPI Transform3s {
   /// @brief set the transform to a random transform
   inline void setRandom();
 
+  /// @brief Comparison operator
   bool operator==(const Transform3s& other) const {
     return (R == other.getRotation()) && (T == other.getTranslation());
   }
 
+  /// @brief Comparison operator
   bool operator!=(const Transform3s& other) const { return !(*this == other); }
 
   /// @brief Prints the transform to the provided output stream.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -51,6 +51,7 @@ set(
   pickle.hh
   utils/std-pair.hh
   serializable.hh
+  printable.hh
 )
 
 set(

--- a/python/collision.cc
+++ b/python/collision.cc
@@ -44,6 +44,7 @@ COAL_COMPILER_DIAGNOSTIC_POP
 #include "coal.hh"
 #include "deprecation.hh"
 #include "serializable.hh"
+#include "printable.hh"
 
 #ifdef COAL_HAS_DOXYGEN_AUTODOC
 #include "doxygen_autodoc/functions.h"
@@ -166,7 +167,8 @@ void exposeCollisionAPI() {
         .DEF_RW_CLASS_ATTRIB(CollisionRequest, security_margin)
         .DEF_RW_CLASS_ATTRIB(CollisionRequest, break_distance)
         .DEF_RW_CLASS_ATTRIB(CollisionRequest, distance_upper_bound)
-        .def(SerializableVisitor<CollisionRequest>());
+        .def(SerializableVisitor<CollisionRequest>())
+        .def(PrintableVisitor<CollisionRequest>());
   }
 
   if (!eigenpy::register_symbolic_link_to_registered_type<
@@ -205,7 +207,9 @@ void exposeCollisionAPI() {
         .DEF_RW_CLASS_ATTRIB(Contact, pos)
         .DEF_RW_CLASS_ATTRIB(Contact, penetration_depth)
         .def(self == self)
-        .def(self != self);
+        .def(self != self)
+        .def(SerializableVisitor<Contact>())
+        .def(PrintableVisitor<Contact>());
   }
 
   if (!eigenpy::register_symbolic_link_to_registered_type<
@@ -245,7 +249,8 @@ void exposeCollisionAPI() {
              return_internal_reference<>())
 
         .DEF_RW_CLASS_ATTRIB(CollisionResult, distance_lower_bound)
-        .def(SerializableVisitor<CollisionResult>());
+        .def(SerializableVisitor<CollisionResult>())
+        .def(PrintableVisitor<CollisionResult>());
   }
 
   if (!eigenpy::register_symbolic_link_to_registered_type<

--- a/python/contact_patch.cc
+++ b/python/contact_patch.cc
@@ -36,10 +36,11 @@
 
 #include "coal/fwd.hh"
 #include "coal/contact_patch.h"
-#include "coal/serialization/collision_data.h"
+#include "coal/serialization/contact_patch.h"
 
 #include "coal.hh"
 #include "deprecation.hh"
+#include "printable.hh"
 #include "serializable.hh"
 
 #ifdef COAL_HAS_DOXYGEN_AUTODOC
@@ -80,7 +81,9 @@ void exposeContactPatchAPI() {
         .DEF_CLASS_FUNC(ContactPatch, getPointShape1)
         .DEF_CLASS_FUNC(ContactPatch, getPointShape2)
         .DEF_CLASS_FUNC(ContactPatch, clear)
-        .DEF_CLASS_FUNC(ContactPatch, isSame);
+        .DEF_CLASS_FUNC(ContactPatch, isSame)
+        .def(SerializableVisitor<ContactPatch>())
+        .def(PrintableVisitor<ContactPatch>());
   }
 
   if (!eigenpy::register_symbolic_link_to_registered_type<
@@ -103,7 +106,9 @@ void exposeContactPatchAPI() {
         .DEF_CLASS_FUNC(ContactPatchRequest, getNumSamplesCurvedShapes)
         .DEF_CLASS_FUNC(ContactPatchRequest, setNumSamplesCurvedShapes)
         .DEF_CLASS_FUNC(ContactPatchRequest, getPatchTolerance)
-        .DEF_CLASS_FUNC(ContactPatchRequest, setPatchTolerance);
+        .DEF_CLASS_FUNC(ContactPatchRequest, setPatchTolerance)
+        .def(SerializableVisitor<ContactPatchRequest>())
+        .def(PrintableVisitor<ContactPatchRequest>());
   }
 
   if (!eigenpy::register_symbolic_link_to_registered_type<
@@ -119,12 +124,15 @@ void exposeContactPatchAPI() {
                                init<>(arg("self"), "Default constructor."))
         .def(dv::init<ContactPatchResult, ContactPatchRequest>())
         .DEF_CLASS_FUNC(ContactPatchResult, numContactPatches)
-        .DEF_CLASS_FUNC(ContactPatchResult, getUnusedContactPatch)
+        .DEF_CLASS_FUNC2(ContactPatchResult, getUnusedContactPatch,
+                         return_value_policy<reference_existing_object>())
         .DEF_CLASS_FUNC2(ContactPatchResult, getContactPatch,
                          return_value_policy<copy_const_reference>())
         .DEF_CLASS_FUNC(ContactPatchResult, clear)
         .DEF_CLASS_FUNC(ContactPatchResult, set)
-        .DEF_CLASS_FUNC(ContactPatchResult, check);
+        .DEF_CLASS_FUNC(ContactPatchResult, check)
+        .def(SerializableVisitor<ContactPatchResult>())
+        .def(PrintableVisitor<ContactPatchResult>());
   }
 
   if (!eigenpy::register_symbolic_link_to_registered_type<

--- a/python/distance.cc
+++ b/python/distance.cc
@@ -46,6 +46,7 @@ COAL_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
 COAL_COMPILER_DIAGNOSTIC_POP
 
 #include "serializable.hh"
+#include "printable.hh"
 
 #ifdef COAL_HAS_DOXYGEN_AUTODOC
 #include "doxygen_autodoc/functions.h"
@@ -109,7 +110,8 @@ void exposeDistanceAPI() {
         .DEF_RW_CLASS_ATTRIB(DistanceRequest, enable_signed_distance)
         .DEF_RW_CLASS_ATTRIB(DistanceRequest, rel_err)
         .DEF_RW_CLASS_ATTRIB(DistanceRequest, abs_err)
-        .def(SerializableVisitor<DistanceRequest>());
+        .def(SerializableVisitor<DistanceRequest>())
+        .def(PrintableVisitor<DistanceRequest>());
   }
   COAL_COMPILER_DIAGNOSTIC_POP
 
@@ -138,7 +140,8 @@ void exposeDistanceAPI() {
 
         .def("clear", &DistanceResult::clear,
              doxygen::member_func_doc(&DistanceResult::clear))
-        .def(SerializableVisitor<DistanceResult>());
+        .def(SerializableVisitor<DistanceResult>())
+        .def(PrintableVisitor<DistanceResult>());
   }
 
   if (!eigenpy::register_symbolic_link_to_registered_type<

--- a/python/math.cc
+++ b/python/math.cc
@@ -42,6 +42,7 @@
 #include "coal.hh"
 #include "pickle.hh"
 #include "serializable.hh"
+#include "printable.hh"
 
 #ifdef COAL_HAS_DOXYGEN_AUTODOC
 #include "doxygen_autodoc/coal/math/transform.h"
@@ -169,7 +170,8 @@ void exposeMaths() {
       .def(self == self)
       .def(self != self)
       .def_pickle(PickleObject<Transform3s>())
-      .def(SerializableVisitor<Transform3s>());
+      .def(SerializableVisitor<Transform3s>())
+      .def(PrintableVisitor<Transform3s>());
 
   exposeTriangle<Triangle32::IndexType>("Triangle32");
   bp::scope().attr("Triangle") = bp::scope().attr("Triangle32");

--- a/python/printable.hh
+++ b/python/printable.hh
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2026 INRIA
+// This file was borrowed from the Pinocchio library:
+// https://github.com/stack-of-tasks/pinocchio
+//
+
+#ifndef COAL_PYTHON_PRINTABLE_H
+#define COAL_PYTHON_PRINTABLE_H
+
+#include <boost/python.hpp>
+
+namespace coal {
+namespace python {
+
+namespace bp = boost::python;
+
+///
+/// \brief Set the Python method __str__ and __repr__ to use the overloading
+/// operator<<.
+///
+template <class C>
+struct PrintableVisitor : public bp::def_visitor<PrintableVisitor<C>> {
+  template <class PyClass>
+  void visit(PyClass& cl) const {
+    cl.def(bp::self_ns::str(bp::self_ns::self))
+        .def(bp::self_ns::repr(bp::self_ns::self));
+  }
+};
+
+}  // namespace python
+}  // namespace coal
+
+#endif  // ifndef COAL_PYTHON_PRINTABLE_H

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -326,11 +326,6 @@ Quats makeQuat(Scalar w, Scalar x, Scalar y, Scalar z) {
   return q;
 }
 
-std::ostream& operator<<(std::ostream& os, const Transform3s& tf) {
-  return os << "[ " << tf.getTranslation().format(vfmt) << ", "
-            << tf.getQuatRotation().coeffs().format(vfmt) << " ]";
-}
-
 std::size_t getNbRun(const int& argc, char const* const* argv,
                      std::size_t defaultValue) {
   for (int i = 0; i < argc; ++i)

--- a/test/utility.h
+++ b/test/utility.h
@@ -168,8 +168,6 @@ std::string getNodeTypeName(NODE_TYPE node_type);
 
 Quats makeQuat(Scalar w, Scalar x, Scalar y, Scalar z);
 
-std::ostream& operator<<(std::ostream& os, const Transform3s& tf);
-
 /// Get the argument --nb-run from argv
 std::size_t getNbRun(const int& argc, char const* const* argv,
                      std::size_t defaultValue);


### PR DESCRIPTION
Simple PR to add printing capabilities (C++ and python) for collision data (`Contact`, `CollisionRequest`, `CollisionResult`, `DistanceRequest`, `DistanceResult`, `ContactPatch`, `ContactPatchRequest` and `ContactPatchResult`).

I also took the opportunity to add missing `SeriablizableVisitor` to collision data.