### PR TITLE
Collision data: fix equality operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add missing calls to computeLocalAABB for internal objects ([#819](https://github.com/coal-library/coal/pull/819))
 - Add missing override specifiers ([#820](https://github.com/coal-library/coal/pull/820))
 - Fix Python error when accessing `geometry.convex` on BVH geometris ([#833](https://github.com/coal-library/coal/pull/833))
+- Fix `Contact` and `CollisionResult` operator==: if the `o1/o2` pointers are different, we check whether or not the underlying geometries are the same ([#856](https://github.com/coal-library/coal/pull/820)). This is typically important in the context of serialization.
 
 ### Changed
 - Float precision ([#665](https://github.com/coal-library/coal/pull/665))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add missing calls to computeLocalAABB for internal objects ([#819](https://github.com/coal-library/coal/pull/819))
 - Add missing override specifiers ([#820](https://github.com/coal-library/coal/pull/820))
 - Fix Python error when accessing `geometry.convex` on BVH geometris ([#833](https://github.com/coal-library/coal/pull/833))
-- Fix `Contact` and `CollisionResult` operator==: if the `o1/o2` pointers are different, we check whether or not the underlying geometries are the same ([#856](https://github.com/coal-library/coal/pull/820)). This is typically important in the context of serialization.
+- Fix `Contact`, `CollisionResult` and `DistanceResult` operator== ([#856](https://github.com/coal-library/coal/pull/820)):
+  - If the `o1/o2` pointers are different, we check whether or not the underlying geometries are the same. This is typically important in the context of serialization.
+  - Fix using NaN to initialize collision data (`Contact`, `CollisionResult`, `DistanceResult`). This prevents the absurd `Contact contact; contact == contact; // false` problem.
+  - Fix NaNs coming from GJK/EPA when the algorithms (correctly) early stopped. NaNs indicate failure. In the case that GJK/EPA early stopped but ran fine, we set non-computed data to inf instead of NaN.
 
 ### Changed
 - Float precision ([#665](https://github.com/coal-library/coal/pull/665))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add print methods for collision data (`Contact`, `CollisionRequest`, `CollisionResult`, `DistanceRequest`, `DistanceResult`, `ContactPatch`, `ContactPatchRequest` and `ContactPatchResult`) ([854](https://github.com/coal-library/coal/pull/854)).
   - One can now do `std::cout << contact` for example.
   - Added the `PrintableVisitor` in python bindings so that `print(contact)` works in python as well
-- Add `remap` method to `Contact` and `DistanceResult` to remap the `o1/o2` pointers (typically after serialization/deserialization) ([855](https://github.com/coal-library/coal/pull/855)).
+- Added `resolveReferences` method to `Contact` and `DistanceResult` to remap the `o1/o2` pointers (typically after serialization/deserialization) ([855](https://github.com/coal-library/coal/pull/855)).
+- Added copy constructors to `Contact::Contact(const Contact& other, const CollisionGeometry* new_o1, const CollisionGeometry* new_o2)` and `DistanceResult::DistanceResult(const DistanceResult& other, const CollisionGeometry* new_o1, const CollisionGeometry* new_o2)` to allow copying a `Contact` or `DistanceResult` while remapping the `o1/o2` pointers to new geometries. This is typically useful in the context of deep-copying ([#856](https://github.com/coal-library/coal/pull/820)).
 
 ### Removed
 - Remove direct dependency to ([#744](https://github.com/coal-library/coal/pull/744)):

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -152,16 +152,38 @@ struct COAL_DLLAPI Contact {
     return b1 < other.b1;
   }
 
+  /// @brief Equality operator. Two contacts are considered equal if they have
+  /// the same normal, the same nearest points and the same penetration depth
+  /// and if the shapes they point to are equal.
+  /// Note: two contacts may be equal even if they point to different collision
+  /// geometries o1/o2, as long as these geometries are equal.
   bool operator==(const Contact& other) const {
-    return o1 == other.o1 && o2 == other.o2 && b1 == other.b1 &&
-           b2 == other.b2 && normal == other.normal && pos == other.pos &&
-           nearest_points[0] == other.nearest_points[0] &&
-           nearest_points[1] == other.nearest_points[1] &&
-           penetration_depth == other.penetration_depth;
+    if (this == &other) return true;
+
+    COAL_EQUAL_OPERATOR_CHECK(((o1 == nullptr && other.o1 == nullptr) ||
+                               (o1 != nullptr && other.o1 != nullptr)));
+    COAL_EQUAL_OPERATOR_CHECK(((o2 == nullptr && other.o2 == nullptr) ||
+                               (o2 != nullptr && other.o2 != nullptr)));
+    if ((o1 && other.o1) && (o1 != other.o1))
+      COAL_EQUAL_OPERATOR_CHECK(*o1 == *other.o1);
+    if ((o2 && other.o2) && (o2 != other.o2))
+      COAL_EQUAL_OPERATOR_CHECK(*o2 == *other.o2);
+    COAL_EQUAL_OPERATOR_CHECK(b1 == other.b1);
+    COAL_EQUAL_OPERATOR_CHECK(b2 == other.b2);
+    COAL_EQUAL_OPERATOR_CHECK(normal == other.normal);
+    COAL_EQUAL_OPERATOR_CHECK(pos == other.pos);
+    COAL_EQUAL_OPERATOR_CHECK(nearest_points[0] == other.nearest_points[0]);
+    COAL_EQUAL_OPERATOR_CHECK(nearest_points[1] == other.nearest_points[1]);
+    COAL_EQUAL_OPERATOR_CHECK(penetration_depth == other.penetration_depth);
+
+    return true;
   }
 
+  /// @brief Inequality operator. Negation of the equality operator.
   bool operator!=(const Contact& other) const { return !(*this == other); }
 
+  /// @brief Returns the distance to collision: penetration depth - security
+  /// margin.
   Scalar getDistanceToCollision(const CollisionRequest& request) const;
 
   /// @brief (re)Map the pointers o1/o2 to the provided collision objects.
@@ -356,6 +378,18 @@ struct COAL_DLLAPI QueryResult {
   QueryResult()
       : cached_gjk_guess(Vec3s::Zero()),
         cached_support_func_guess(support_func_guess_t::Constant(-1)) {}
+
+  /// @brief Comparison operator.
+  inline bool operator==(const QueryResult& other) const {
+    if (this == &other) return true;
+
+    COAL_EQUAL_OPERATOR_CHECK(cached_gjk_guess == other.cached_gjk_guess);
+    COAL_EQUAL_OPERATOR_CHECK(cached_support_func_guess ==
+                              other.cached_support_func_guess);
+    COAL_EQUAL_OPERATOR_CHECK(timings == other.timings);
+
+    return true;
+  }
 
   /// @brief Prints the query result to the provided output stream.
   void disp(std::ostream& os, const std::string& prefix = "") const {
@@ -1463,26 +1497,30 @@ struct COAL_DLLAPI DistanceResult : QueryResult {
     timings.clear();
   }
 
-  /// @brief whether two DistanceResult are the same or not
+  /// @brief Whether two DistanceResult are the same or not.
+  /// This compares the two results terms by terms.
+  /// Note: two results may be equal even if they point to different collision
+  /// geometries o1/o2, as long as these geometries are equal.
   inline bool operator==(const DistanceResult& other) const {
-    bool is_same = min_distance == other.min_distance &&
-                   nearest_points[0] == other.nearest_points[0] &&
-                   nearest_points[1] == other.nearest_points[1] &&
-                   normal == other.normal && o1 == other.o1 && o2 == other.o2 &&
-                   b1 == other.b1 && b2 == other.b2;
+    if (this == &other) return true;
 
-    // TODO: check also that two GeometryObject are indeed equal.
-    if ((o1 != NULL) ^ (other.o1 != NULL)) return false;
-    is_same &= (o1 == other.o1);
-    //    else if (o1 != NULL and other.o1 != NULL) is_same &= *o1 ==
-    //    *other.o1;
+    COAL_EQUAL_OPERATOR_CHECK((QueryResult::operator==(other)));
+    COAL_EQUAL_OPERATOR_CHECK(min_distance == other.min_distance);
+    COAL_EQUAL_OPERATOR_CHECK(nearest_points[0] == other.nearest_points[0]);
+    COAL_EQUAL_OPERATOR_CHECK(nearest_points[1] == other.nearest_points[1]);
+    COAL_EQUAL_OPERATOR_CHECK(normal == other.normal);
+    COAL_EQUAL_OPERATOR_CHECK(((o1 == nullptr && other.o1 == nullptr) ||
+                               (o1 != nullptr && other.o1 != nullptr)));
+    COAL_EQUAL_OPERATOR_CHECK(((o2 == nullptr && other.o2 == nullptr) ||
+                               (o2 != nullptr && other.o2 != nullptr)));
+    if ((o1 && other.o1) && (o1 != other.o1))
+      COAL_EQUAL_OPERATOR_CHECK(*o1 == *other.o1);
+    if ((o2 && other.o2) && (o2 != other.o2))
+      COAL_EQUAL_OPERATOR_CHECK(*o2 == *other.o2);
+    COAL_EQUAL_OPERATOR_CHECK(b1 == other.b1);
+    COAL_EQUAL_OPERATOR_CHECK(b2 == other.b2);
 
-    if ((o2 != NULL) ^ (other.o2 != NULL)) return false;
-    is_same &= (o2 == other.o2);
-    //    else if (o2 != NULL and other.o2 != NULL) is_same &= *o2 ==
-    //    *other.o2;
-
-    return is_same;
+    return true;
   }
 
   /// @brief whether two DistanceResult are different or not

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -121,16 +121,17 @@ struct COAL_DLLAPI Contact {
   Contact(const Contact& other) = default;
   Contact& operator=(const Contact& other) = default;
 
-  /// @brief Copy constructor using an other contact and two CollisionGeometry
-  /// pointers. This constructor allows to copy the contact information from an
-  /// other contact, but remap the pointers to the collision geometries to the
-  /// provided ones. This is usefull in a deep-copy context, when the collision
-  /// geometries are also copied and the pointers in the contact need to be
-  /// remapped to the new collision geometries.
-  Contact(const Contact& other, const CollisionGeometry* new_o1,
-          const CollisionGeometry* new_o2)
+  /// @brief Copy constructor using an other contact and a pair of
+  /// CollisionGeometry pointers. This constructor allows to copy the contact
+  /// information from an other contact, but remap the pointers to the collision
+  /// geometries to the provided ones. This is usefull in a deep-copy context,
+  /// when the collision geometries are also copied and the pointers in the
+  /// contact need to be remapped to the new collision geometries.
+  Contact(
+      const Contact& other,
+      std::pair<const CollisionGeometry*, const CollisionGeometry*> new_o1_o2)
       : Contact(other) {
-    resolveReferences(new_o1, new_o2);
+    resolveReferences(new_o1_o2);
   }
 
   Contact(const CollisionGeometry* o1_, const CollisionGeometry* o2_, int b1_,
@@ -204,14 +205,14 @@ struct COAL_DLLAPI Contact {
   /// margin.
   Scalar getDistanceToCollision(const CollisionRequest& request) const;
 
-  /// @brief (re)Map the pointers o1/o2 to the provided collision objects.
+  /// @brief Resolve internal references to the pair of collision geometries.
   /// This is useful when deserializing a contact, as the pointers to the
   /// collision objects are not valid anymore and need to be remapped to the
   /// collision objects in the current context.
-  void resolveReferences(const CollisionGeometry* new_o1,
-                         const CollisionGeometry* new_o2) {
-    o1 = new_o1;
-    o2 = new_o2;
+  void resolveReferences(
+      std::pair<const CollisionGeometry*, const CollisionGeometry*> new_o1_o2) {
+    o1 = new_o1_o2.first;
+    o2 = new_o1_o2.second;
   }
 
   /// \brief Prints the contact to the provided output stream.
@@ -591,22 +592,29 @@ struct COAL_DLLAPI CollisionResult : QueryResult {
   /// to the provided ones. This is usefull in a deep-copy context, when the
   /// collision geometries are also copied and the pointers in the collision
   /// result need to be remapped to the new collision geometries.
-  CollisionResult(const CollisionResult& other,
-                  const std::vector<const CollisionGeometry*>& new_geometries1,
-                  const std::vector<const CollisionGeometry*>& new_geometries2)
+  CollisionResult(
+      const CollisionResult& other,
+      const std::vector<std::pair<const CollisionGeometry*,
+                                  const CollisionGeometry*>>& new_geometries)
       : CollisionResult(other) {
+    resolveReferences(new_geometries);
+  }
+
+  /// @brief Resolve the internal points the pointers in the contacts to the
+  /// provided pairs of collision geometries. This is useful when deep-copying
+  /// or deserializing a collision result, as the pointers to the collision
+  /// objects are not valid anymore and need to be remapped to the collision
+  /// objects in the current context.
+  void resolveReferences(
+      const std::vector<std::pair<const CollisionGeometry*,
+                                  const CollisionGeometry*>>& new_geometries) {
     COAL_THROW_PRETTY_IF(
-        new_geometries1.size() != new_geometries2.size(), std::invalid_argument,
-        "The two vectors of collision geometries must have the same size.");
-    COAL_THROW_PRETTY_IF(
-        (contacts.size() != new_geometries1.size()) ||
-            (contacts.size() != new_geometries2.size()),
-        std::invalid_argument,
+        contacts.size() != new_geometries.size(), std::invalid_argument,
         "The size of the vectors of collision geometries must be equal to "
         "the number of contacts in the collision result.");
 
     for (std::size_t i = 0; i < contacts.size(); ++i) {
-      contacts[i].resolveReferences(new_geometries1[i], new_geometries2[i]);
+      contacts[i].resolveReferences(new_geometries[i]);
     }
   }
 
@@ -1491,26 +1499,27 @@ struct COAL_DLLAPI DistanceResult : QueryResult {
   DistanceResult(const DistanceResult& other) = default;
   DistanceResult& operator=(const DistanceResult& other) = default;
 
-  /// @brief Copy constructor using another result and two CollisionGeometry
-  /// pointers. This constructor allows to copy the contact information from an
-  /// other contact, but remap the pointers to the collision geometries to the
-  /// provided ones. This is usefull in a deep-copy context, when the collision
-  /// geometries are also copied and the pointers in the contact need to be
-  /// remapped to the new collision geometries.
-  DistanceResult(const DistanceResult& other, const CollisionGeometry* new_o1,
-                 const CollisionGeometry* new_o2)
+  /// @brief Copy constructor using another result and a pair of
+  /// CollisionGeometry pointers. This constructor allows to copy the contact
+  /// information from an other contact, but remap the pointers to the collision
+  /// geometries to the provided ones. This is usefull in a deep-copy context,
+  /// when the collision geometries are also copied and the pointers in the
+  /// contact need to be remapped to the new collision geometries.
+  DistanceResult(
+      const DistanceResult& other,
+      std::pair<const CollisionGeometry*, const CollisionGeometry*> new_o1_o2)
       : DistanceResult(other) {
-    resolveReferences(new_o1, new_o2);
+    resolveReferences(new_o1_o2);
   }
 
   /// @brief (re)Map the pointers o1/o2 to the provided collision objects.
   /// This is useful when deserializing a result, as the pointers to the
   /// collision objects are not valid anymore and need to be remapped to the
   /// collision objects in the current context.
-  void resolveReferences(const CollisionGeometry* o1_,
-                         const CollisionGeometry* o2_) {
-    o1 = o1_;
-    o2 = o2_;
+  void resolveReferences(
+      std::pair<const CollisionGeometry*, const CollisionGeometry*> new_o1_o2) {
+    o1 = new_o1_o2.first;
+    o2 = new_o1_o2.second;
   }
 
   /// @brief add distance information into the result

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -115,6 +115,24 @@ struct COAL_DLLAPI Contact {
         Vec3s::Constant(std::numeric_limits<Scalar>::max());
   }
 
+  /// @brief Copy constructor.
+  /// This constructor does a raw copy of the contact information, including the
+  /// pointers to the collision geometries.
+  Contact(const Contact& other) = default;
+  Contact& operator=(const Contact& other) = default;
+
+  /// @brief Copy constructor using an other contact and two CollisionGeometry
+  /// pointers. This constructor allows to copy the contact information from an
+  /// other contact, but remap the pointers to the collision geometries to the
+  /// provided ones. This is usefull in a deep-copy context, when the collision
+  /// geometries are also copied and the pointers in the contact need to be
+  /// remapped to the new collision geometries.
+  Contact(const Contact& other, const CollisionGeometry* new_o1,
+          const CollisionGeometry* new_o2)
+      : Contact(other) {
+    resolveReferences(new_o1, new_o2);
+  }
+
   Contact(const CollisionGeometry* o1_, const CollisionGeometry* o2_, int b1_,
           int b2_)
       : o1(o1_), o2(o2_), b1(b1_), b2(b2_) {
@@ -555,10 +573,41 @@ struct COAL_DLLAPI CollisionResult : QueryResult {
   std::array<Vec3s, 2> nearest_points;
 
  public:
+  /// @brief Default constructor.
   CollisionResult()
       : distance_lower_bound((std::numeric_limits<Scalar>::max)()) {
     nearest_points[0] = nearest_points[1] = normal =
         Vec3s::Constant(std::numeric_limits<Scalar>::max());
+  }
+
+  /// @brief Copy constructor.
+  CollisionResult(const CollisionResult& other) = default;
+  CollisionResult& operator=(const CollisionResult& other) = default;
+
+  /// @brief Copy constructor from an other CollisionResult and two vectors of
+  /// CollisionGeometry pointers.
+  /// This constructor allows to copy the collision result information from an
+  /// other collision result, but remap the pointers to the collision geometries
+  /// to the provided ones. This is usefull in a deep-copy context, when the
+  /// collision geometries are also copied and the pointers in the collision
+  /// result need to be remapped to the new collision geometries.
+  CollisionResult(const CollisionResult& other,
+                  const std::vector<const CollisionGeometry*>& new_geometries1,
+                  const std::vector<const CollisionGeometry*>& new_geometries2)
+      : CollisionResult(other) {
+    COAL_THROW_PRETTY_IF(
+        new_geometries1.size() != new_geometries2.size(), std::invalid_argument,
+        "The two vectors of collision geometries must have the same size.");
+    COAL_THROW_PRETTY_IF(
+        (contacts.size() != new_geometries1.size()) ||
+            (contacts.size() != new_geometries2.size()),
+        std::invalid_argument,
+        "The size of the vectors of collision geometries must be equal to "
+        "the number of contacts in the collision result.");
+
+    for (std::size_t i = 0; i < contacts.size(); ++i) {
+      contacts[i].resolveReferences(new_geometries1[i], new_geometries2[i]);
+    }
   }
 
   /// @brief Update the lower bound only if the distance is inferior.
@@ -1429,10 +1478,29 @@ struct COAL_DLLAPI DistanceResult : QueryResult {
   /// @brief invalid contact primitive information
   static const int NONE = -1;
 
+  /// @brief Default constructor.
   DistanceResult(Scalar min_distance_ = (std::numeric_limits<Scalar>::max)())
       : min_distance(min_distance_), o1(NULL), o2(NULL), b1(NONE), b2(NONE) {
     const Vec3s inf(Vec3s::Constant(std::numeric_limits<Scalar>::max()));
     nearest_points[0] = nearest_points[1] = normal = inf;
+  }
+
+  /// @brief Copy constructor.
+  /// This constructor does a raw copy of the contact information, including the
+  /// pointers to the collision geometries.
+  DistanceResult(const DistanceResult& other) = default;
+  DistanceResult& operator=(const DistanceResult& other) = default;
+
+  /// @brief Copy constructor using another result and two CollisionGeometry
+  /// pointers. This constructor allows to copy the contact information from an
+  /// other contact, but remap the pointers to the collision geometries to the
+  /// provided ones. This is usefull in a deep-copy context, when the collision
+  /// geometries are also copied and the pointers in the contact need to be
+  /// remapped to the new collision geometries.
+  DistanceResult(const DistanceResult& other, const CollisionGeometry* new_o1,
+                 const CollisionGeometry* new_o2)
+      : DistanceResult(other) {
+    resolveReferences(new_o1, new_o2);
   }
 
   /// @brief (re)Map the pointers o1/o2 to the provided collision objects.

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -190,7 +190,8 @@ struct COAL_DLLAPI Contact {
   /// This is useful when deserializing a contact, as the pointers to the
   /// collision objects are not valid anymore and need to be remapped to the
   /// collision objects in the current context.
-  void remap(const CollisionGeometry* new_o1, const CollisionGeometry* new_o2) {
+  void resolveReferences(const CollisionGeometry* new_o1,
+                         const CollisionGeometry* new_o2) {
     o1 = new_o1;
     o2 = new_o2;
   }
@@ -1438,7 +1439,8 @@ struct COAL_DLLAPI DistanceResult : QueryResult {
   /// This is useful when deserializing a result, as the pointers to the
   /// collision objects are not valid anymore and need to be remapped to the
   /// collision objects in the current context.
-  void remap(const CollisionGeometry* o1_, const CollisionGeometry* o2_) {
+  void resolveReferences(const CollisionGeometry* o1_,
+                         const CollisionGeometry* o2_) {
     o1 = o1_;
     o2 = o2_;
   }

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -112,7 +112,7 @@ struct COAL_DLLAPI Contact {
   Contact() : o1(NULL), o2(NULL), b1(NONE), b2(NONE) {
     penetration_depth = (std::numeric_limits<Scalar>::max)();
     nearest_points[0] = nearest_points[1] = normal = pos =
-        Vec3s::Constant(std::numeric_limits<Scalar>::quiet_NaN());
+        Vec3s::Constant(std::numeric_limits<Scalar>::max());
   }
 
   Contact(const CollisionGeometry* o1_, const CollisionGeometry* o2_, int b1_,
@@ -120,7 +120,7 @@ struct COAL_DLLAPI Contact {
       : o1(o1_), o2(o2_), b1(b1_), b2(b2_) {
     penetration_depth = (std::numeric_limits<Scalar>::max)();
     nearest_points[0] = nearest_points[1] = normal = pos =
-        Vec3s::Constant(std::numeric_limits<Scalar>::quiet_NaN());
+        Vec3s::Constant(std::numeric_limits<Scalar>::max());
   }
 
   Contact(const CollisionGeometry* o1_, const CollisionGeometry* o2_, int b1_,
@@ -557,7 +557,7 @@ struct COAL_DLLAPI CollisionResult : QueryResult {
   CollisionResult()
       : distance_lower_bound((std::numeric_limits<Scalar>::max)()) {
     nearest_points[0] = nearest_points[1] = normal =
-        Vec3s::Constant(std::numeric_limits<Scalar>::quiet_NaN());
+        Vec3s::Constant(std::numeric_limits<Scalar>::max());
   }
 
   /// @brief Update the lower bound only if the distance is inferior.
@@ -629,7 +629,7 @@ struct COAL_DLLAPI CollisionResult : QueryResult {
     contacts.clear();
     timings.clear();
     nearest_points[0] = nearest_points[1] = normal =
-        Vec3s::Constant(std::numeric_limits<Scalar>::quiet_NaN());
+        Vec3s::Constant(std::numeric_limits<Scalar>::max());
   }
 
   /// @brief reposition Contact objects when fcl inverts them
@@ -1430,8 +1430,8 @@ struct COAL_DLLAPI DistanceResult : QueryResult {
 
   DistanceResult(Scalar min_distance_ = (std::numeric_limits<Scalar>::max)())
       : min_distance(min_distance_), o1(NULL), o2(NULL), b1(NONE), b2(NONE) {
-    const Vec3s nan(Vec3s::Constant(std::numeric_limits<Scalar>::quiet_NaN()));
-    nearest_points[0] = nearest_points[1] = normal = nan;
+    const Vec3s inf(Vec3s::Constant(std::numeric_limits<Scalar>::max()));
+    nearest_points[0] = nearest_points[1] = normal = inf;
   }
 
   /// @brief (re)Map the pointers o1/o2 to the provided collision objects.
@@ -1487,13 +1487,13 @@ struct COAL_DLLAPI DistanceResult : QueryResult {
 
   /// @brief clear the result
   void clear() {
-    const Vec3s nan(Vec3s::Constant(std::numeric_limits<Scalar>::quiet_NaN()));
+    const Vec3s inf(Vec3s::Constant(std::numeric_limits<Scalar>::max()));
     min_distance = (std::numeric_limits<Scalar>::max)();
     o1 = NULL;
     o2 = NULL;
     b1 = NONE;
     b2 = NONE;
-    nearest_points[0] = nearest_points[1] = normal = nan;
+    nearest_points[0] = nearest_points[1] = normal = inf;
     timings.clear();
   }
 

--- a/include/coal/fwd.hh
+++ b/include/coal/fwd.hh
@@ -71,6 +71,11 @@
     throw exception(ss.str());                             \
   }
 
+#define COAL_THROW_PRETTY_IF(condition, exception, message) \
+  if ((condition)) {                                        \
+    COAL_THROW_PRETTY(message, exception);                  \
+  }
+
 #ifndef COAL_EQUAL_OPERATOR_CHECK
 #define COAL_EQUAL_OPERATOR_CHECK(boolean) \
   if (!(boolean)) {                        \

--- a/include/coal/fwd.hh
+++ b/include/coal/fwd.hh
@@ -71,6 +71,13 @@
     throw exception(ss.str());                             \
   }
 
+#ifndef COAL_EQUAL_OPERATOR_CHECK
+#define COAL_EQUAL_OPERATOR_CHECK(boolean) \
+  if (!(boolean)) {                        \
+    return false;                          \
+  }
+#endif
+
 #ifdef COAL_TURN_ASSERT_INTO_EXCEPTION
 #define COAL_ASSERT(check, message, exception) \
   do {                                         \

--- a/include/coal/narrowphase/narrowphase.h
+++ b/include/coal/narrowphase/narrowphase.h
@@ -504,7 +504,7 @@ struct COAL_DLLAPI GJKSolver {
         break;
       case details::GJK::Collision:
         if (!compute_penetration) {
-          // Skip EPA and set the witness points and the normal to nans.
+          // Skip EPA and set the witness points and the normal to inf.
           GJKCollisionExtractWitnessPointsAndNormal(tf1, distance, p1, p2,
                                                     normal);
         } else {
@@ -601,8 +601,8 @@ struct COAL_DLLAPI GJKSolver {
     this->support_func_cached_guess = this->gjk.support_hint;
 
     distance = Scalar(this->gjk.distance);
-    p1 = p2 = normal =
-        Vec3s::Constant(std::numeric_limits<Scalar>::quiet_NaN());
+    // we set to max as a default value
+    p1 = p2 = normal = Vec3s::Constant(std::numeric_limits<Scalar>::max());
     // If we absolutely want to return some witness points, we could use
     // the following code (or simply merge the early stopped case with the
     // valid case below):
@@ -660,8 +660,7 @@ struct COAL_DLLAPI GJKSolver {
     this->support_func_cached_guess = this->gjk.support_hint;
 
     distance = Scalar(this->gjk.distance);
-    p1 = p2 = normal =
-        Vec3s::Constant(std::numeric_limits<Scalar>::quiet_NaN());
+    p1 = p2 = normal = Vec3s::Constant(std::numeric_limits<Scalar>::max());
   }
 
   void EPAExtractWitnessPointsAndNormal(const Transform3s& tf1,

--- a/include/coal/timings.h
+++ b/include/coal/timings.h
@@ -26,6 +26,16 @@ struct CPUTimes {
     system += rhs.system;
     return *this;
   }
+
+  bool operator==(const CPUTimes& rhs) const {
+    if (this == &rhs) return true;
+
+    COAL_EQUAL_OPERATOR_CHECK(wall == rhs.wall);
+    COAL_EQUAL_OPERATOR_CHECK(user == rhs.user);
+    COAL_EQUAL_OPERATOR_CHECK(system == rhs.system);
+
+    return true;
+  }
 };
 
 inline CPUTimes operator+(CPUTimes lhs, const CPUTimes& rhs) {

--- a/test/serialization.cpp
+++ b/test/serialization.cpp
@@ -282,17 +282,18 @@ BOOST_AUTO_TEST_CASE(test_collision_data) {
   Sphere sphere(1.);
   Box box(Vec3s::Ones());
 
-  auto contact_remap = [&](Contact& c) { c.remap(&sphere, &box); };
+  Contact contact0(&sphere, &box, 1, 2, Vec3s::Ones(), Vec3s::Zero(), -10.);
+  test_serialization(contact0, [&](Contact& c) { c.remap(&sphere, &box); });
 
-  Contact contact(&sphere, &box, 1, 2, Vec3s::Ones(), Vec3s::Zero(), -10.);
-  test_serialization(contact, contact_remap);
+  Contact contact1(NULL, NULL, 1, 2, Vec3s::Ones(), Vec3s::Zero(), -10.);
+  test_serialization(contact1);
 
   CollisionRequest collision_request(CONTACT, 10);
   test_serialization(collision_request);
 
   CollisionResult collision_result;
-  collision_result.addContact(contact);
-  collision_result.addContact(contact);
+  collision_result.addContact(contact0);
+  collision_result.addContact(contact1);
   collision_result.distance_lower_bound = Scalar(0.1);
   collision_result.normal.setOnes();
   collision_result.nearest_points[0].setRandom();
@@ -300,7 +301,8 @@ BOOST_AUTO_TEST_CASE(test_collision_data) {
   test_serialization(collision_result, [&](CollisionResult& cr) {
     for (size_t i = 0; i < cr.numContacts(); ++i) {
       Contact c = cr.getContact(i);
-      contact_remap(c);
+      if (i == 0) c.remap(&sphere, &box);
+      if (i == 1) c.remap(NULL, NULL);
       cr.setContact(i, c);
     }
   });

--- a/test/serialization.cpp
+++ b/test/serialization.cpp
@@ -282,11 +282,18 @@ BOOST_AUTO_TEST_CASE(test_collision_data) {
   Sphere sphere(1.);
   Box box(Vec3s::Ones());
 
+  // testing serialization with valid pointers
+  // we need to add a post load hook to remap the contact's internal pointers to
+  // the shapes
   Contact contact0(&sphere, &box, 1, 2, Vec3s::Ones(), Vec3s::Zero(), -10.);
   test_serialization(contact0, [&](Contact& c) { c.remap(&sphere, &box); });
 
+  // testing serialization with NULL pointers
   Contact contact1(NULL, NULL, 1, 2, Vec3s::Ones(), Vec3s::Zero(), -10.);
   test_serialization(contact1);
+
+  Contact contact2;
+  test_serialization(contact2);
 
   CollisionRequest collision_request(CONTACT, 10);
   test_serialization(collision_request);
@@ -294,6 +301,7 @@ BOOST_AUTO_TEST_CASE(test_collision_data) {
   CollisionResult collision_result;
   collision_result.addContact(contact0);
   collision_result.addContact(contact1);
+  collision_result.addContact(contact2);
   collision_result.distance_lower_bound = Scalar(0.1);
   collision_result.normal.setOnes();
   collision_result.nearest_points[0].setRandom();
@@ -301,8 +309,11 @@ BOOST_AUTO_TEST_CASE(test_collision_data) {
   test_serialization(collision_result, [&](CollisionResult& cr) {
     for (size_t i = 0; i < cr.numContacts(); ++i) {
       Contact c = cr.getContact(i);
+      // case 0: remap to sphere/box
       if (i == 0) c.remap(&sphere, &box);
+      // case 1: remap to NULL/NULL
       if (i == 1) c.remap(NULL, NULL);
+      // case 2: do nothing
       cr.setContact(i, c);
     }
   });

--- a/test/serialization.cpp
+++ b/test/serialization.cpp
@@ -286,7 +286,8 @@ BOOST_AUTO_TEST_CASE(test_collision_data) {
   // we need to add a post load hook to remap the contact's internal pointers to
   // the shapes
   Contact contact0(&sphere, &box, 1, 2, Vec3s::Ones(), Vec3s::Zero(), -10.);
-  test_serialization(contact0, [&](Contact& c) { c.remap(&sphere, &box); });
+  test_serialization(contact0,
+                     [&](Contact& c) { c.resolveReferences({&sphere, &box}); });
 
   // testing serialization with NULL pointers
   Contact contact1(NULL, NULL, 1, 2, Vec3s::Ones(), Vec3s::Zero(), -10.);
@@ -307,15 +308,7 @@ BOOST_AUTO_TEST_CASE(test_collision_data) {
   collision_result.nearest_points[0].setRandom();
   collision_result.nearest_points[1].setRandom();
   test_serialization(collision_result, [&](CollisionResult& cr) {
-    for (size_t i = 0; i < cr.numContacts(); ++i) {
-      Contact c = cr.getContact(i);
-      // case 0: remap to sphere/box
-      if (i == 0) c.remap(&sphere, &box);
-      // case 1: remap to NULL/NULL
-      if (i == 1) c.remap(NULL, NULL);
-      // case 2: do nothing
-      cr.setContact(i, c);
-    }
+    cr.resolveReferences({{&sphere, &box}, {NULL, NULL}, {NULL, NULL}});
   });
 
   DistanceRequest distance_request(true, 1., 2.);
@@ -328,8 +321,9 @@ BOOST_AUTO_TEST_CASE(test_collision_data) {
   distance_result.nearest_points[1].setRandom();
   distance_result.o1 = &sphere;
   distance_result.o2 = &box;
-  test_serialization(distance_result,
-                     [&](DistanceResult& dr) { dr.remap(&sphere, &box); });
+  test_serialization(distance_result, [&](DistanceResult& dr) {
+    dr.resolveReferences({&sphere, &box});
+  });
 
   {
     // Serializing contact patches.


### PR DESCRIPTION
If the pointers o1/o2 don't match in `Contact` or `DistanceResult` then we check wether or not the underlying values match. This is typically important for serialization/deserialization.

Also fixes the initialization of collision data (`Contact`, `CollisionResult`, `DistanceResult`): stuff should not be initialized to NaN. NaN indicates computation failure + with NaN initialization, we get the non-desired behaviour:
```cpp
Contact contact;
contact == contact; // false with NaN init
```