### PR TITLE
Enhance equal operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Added the `PrintableVisitor` in python bindings so that `print(contact)` works in python as well
 - Added `resolveReferences` method to `Contact` and `DistanceResult` to remap the `o1/o2` pointers (typically after serialization/deserialization) ([855](https://github.com/coal-library/coal/pull/855)).
 - Added copy constructors to `Contact::Contact(const Contact& other, const CollisionGeometry* new_o1, const CollisionGeometry* new_o2)` and `DistanceResult::DistanceResult(const DistanceResult& other, const CollisionGeometry* new_o1, const CollisionGeometry* new_o2)` to allow copying a `Contact` or `DistanceResult` while remapping the `o1/o2` pointers to new geometries. This is typically useful in the context of deep-copying ([#856](https://github.com/coal-library/coal/pull/820)).
+- Added the `COAL_EQUAL_OPERATOR_CHECK` macro. This macro can be overridden at compile time, extremely practial for debugging serialization for example. ([#859](https://github.com/coal-library/coal/pull/859))
 
 ### Removed
 - Remove direct dependency to ([#744](https://github.com/coal-library/coal/pull/744)):

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,7 @@ set(
   include/coal/serialization/quadrilateral.h
   include/coal/serialization/triangle.h
   include/coal/timings.h
+  include/coal/shared_ptr_comparison.h
 )
 
 # boost::span requires Boost >= 1.78.0.

--- a/include/coal/BV/AABB.h
+++ b/include/coal/BV/AABB.h
@@ -38,6 +38,7 @@
 #ifndef COAL_AABB_H
 #define COAL_AABB_H
 
+#include "coal/fwd.hh"
 #include "coal/data_types.h"
 
 namespace coal {
@@ -89,7 +90,9 @@ class COAL_DLLAPI AABB {
 
   /// @brief Comparison operator
   bool operator==(const AABB& other) const {
-    return min_ == other.min_ && max_ == other.max_;
+    COAL_EQUAL_OPERATOR_CHECK(min_ == other.min_);
+    COAL_EQUAL_OPERATOR_CHECK(max_ == other.max_);
+    return true;
   }
 
   bool operator!=(const AABB& other) const { return !(*this == other); }

--- a/include/coal/BV/BV_node.h
+++ b/include/coal/BV/BV_node.h
@@ -74,9 +74,10 @@ struct COAL_DLLAPI BVNodeBase {
 
   /// @brief Equality operator
   bool operator==(const BVNodeBase& other) const {
-    return first_child == other.first_child &&
-           first_primitive == other.first_primitive &&
-           num_primitives == other.num_primitives;
+    COAL_EQUAL_OPERATOR_CHECK(first_child == other.first_child);
+    COAL_EQUAL_OPERATOR_CHECK(first_primitive == other.first_primitive);
+    COAL_EQUAL_OPERATOR_CHECK(num_primitives == other.num_primitives);
+    return true;
   }
 
   /// @brief Difference operator
@@ -111,7 +112,9 @@ struct COAL_DLLAPI BVNode : public BVNodeBase {
 
   /// @brief Equality operator
   bool operator==(const BVNode& other) const {
-    return Base::operator==(other) && bv == other.bv;
+    COAL_EQUAL_OPERATOR_CHECK(Base::operator==(other));
+    COAL_EQUAL_OPERATOR_CHECK(bv == other.bv);
+    return true;
   }
 
   /// @brief Difference operator

--- a/include/coal/BV/OBB.h
+++ b/include/coal/BV/OBB.h
@@ -38,6 +38,7 @@
 #ifndef COAL_OBB_H
 #define COAL_OBB_H
 
+#include "coal/fwd.hh"
 #include "coal/data_types.h"
 
 namespace coal {
@@ -68,7 +69,10 @@ struct COAL_DLLAPI OBB {
 
   /// @brief Equality operator
   bool operator==(const OBB& other) const {
-    return axes == other.axes && To == other.To && extent == other.extent;
+    COAL_EQUAL_OPERATOR_CHECK(axes == other.axes);
+    COAL_EQUAL_OPERATOR_CHECK(To == other.To);
+    COAL_EQUAL_OPERATOR_CHECK(extent == other.extent);
+    return true;
   }
 
   /// @brief Difference operator

--- a/include/coal/BV/OBBRSS.h
+++ b/include/coal/BV/OBBRSS.h
@@ -38,6 +38,7 @@
 #ifndef COAL_OBBRSS_H
 #define COAL_OBBRSS_H
 
+#include "coal/fwd.hh"
 #include "coal/BV/OBB.h"
 #include "coal/BV/RSS.h"
 
@@ -61,7 +62,9 @@ struct COAL_DLLAPI OBBRSS {
 
   /// @brief Equality operator
   bool operator==(const OBBRSS& other) const {
-    return obb == other.obb && rss == other.rss;
+    COAL_EQUAL_OPERATOR_CHECK(obb == other.obb);
+    COAL_EQUAL_OPERATOR_CHECK(rss == other.rss);
+    return true;
   }
 
   /// @brief Difference operator

--- a/include/coal/BV/RSS.h
+++ b/include/coal/BV/RSS.h
@@ -38,6 +38,7 @@
 #ifndef COAL_RSS_H
 #define COAL_RSS_H
 
+#include "coal/fwd.hh"
 #include "coal/data_types.h"
 
 #include <boost/math/constants/constants.hpp>
@@ -77,9 +78,12 @@ struct COAL_DLLAPI RSS {
 
   /// @brief Equality operator
   bool operator==(const RSS& other) const {
-    return axes == other.axes && Tr == other.Tr &&
-           length[0] == other.length[0] && length[1] == other.length[1] &&
-           radius == other.radius;
+    COAL_EQUAL_OPERATOR_CHECK(axes == other.axes);
+    COAL_EQUAL_OPERATOR_CHECK(Tr == other.Tr);
+    COAL_EQUAL_OPERATOR_CHECK(length[0] == other.length[0]);
+    COAL_EQUAL_OPERATOR_CHECK(length[1] == other.length[1]);
+    COAL_EQUAL_OPERATOR_CHECK(radius == other.radius);
+    return true;
   }
 
   /// @brief Difference operator

--- a/include/coal/BV/kDOP.h
+++ b/include/coal/BV/kDOP.h
@@ -105,7 +105,8 @@ class COAL_DLLAPI KDOP {
 
   /// @brief Equality operator
   bool operator==(const KDOP& other) const {
-    return (dist_ == other.dist_).all();
+    COAL_EQUAL_OPERATOR_CHECK((dist_ == other.dist_).all());
+    return true;
   }
 
   /// @brief Difference operator

--- a/include/coal/BV/kIOS.h
+++ b/include/coal/BV/kIOS.h
@@ -38,6 +38,7 @@
 #ifndef COAL_KIOS_H
 #define COAL_KIOS_H
 
+#include "coal/fwd.hh"
 #include "coal/BV/OBB.h"
 
 namespace coal {
@@ -58,7 +59,9 @@ class COAL_DLLAPI kIOS {
     Scalar r;
 
     bool operator==(const kIOS_Sphere& other) const {
-      return o == other.o && r == other.r;
+      COAL_EQUAL_OPERATOR_CHECK(o == other.o);
+      COAL_EQUAL_OPERATOR_CHECK(r == other.r);
+      return true;
     }
 
     bool operator!=(const kIOS_Sphere& other) const {
@@ -95,13 +98,11 @@ class COAL_DLLAPI kIOS {
  public:
   /// @brief Equality operator
   bool operator==(const kIOS& other) const {
-    bool res = obb == other.obb && num_spheres == other.num_spheres;
-    if (!res) return false;
-
+    COAL_EQUAL_OPERATOR_CHECK(obb == other.obb);
+    COAL_EQUAL_OPERATOR_CHECK(num_spheres == other.num_spheres);
     for (size_t k = 0; k < num_spheres; ++k) {
-      if (spheres[k] != other.spheres[k]) return false;
+      COAL_EQUAL_OPERATOR_CHECK(spheres[k] == other.spheres[k]);
     }
-
     return true;
   }
 

--- a/include/coal/BVH/BVH_model.h
+++ b/include/coal/BVH/BVH_model.h
@@ -41,6 +41,7 @@
 
 #include "coal/fwd.hh"
 #include "coal/collision_object.h"
+#include "coal/shared_ptr_comparison.h"
 #include "coal/BVH/BVH_internal.h"
 #include "coal/BV/BV_node.h"
 
@@ -444,64 +445,8 @@ class COAL_DLLAPI BVHModel : public BVHModelBase {
     if (other_ptr == nullptr) return false;
     const BVHModel& other = *other_ptr;
 
-    bool res = Base::isEqual(other);
-    if (!res) return false;
-
-    // unsigned int other_num_primitives = 0;
-    // if(other.primitive_indices)
-    // {
-
-    //   switch(other.getModelType())
-    //   {
-    //     case BVH_MODEL_TRIANGLES:
-    //       other_num_primitives = num_tris;
-    //       break;
-    //     case BVH_MODEL_POINTCLOUD:
-    //       other_num_primitives = num_vertices;
-    //       break;
-    //     default:
-    //       ;
-    //   }
-    // }
-
-    //    unsigned int num_primitives = 0;
-    //    if(primitive_indices)
-    //    {
-    //
-    //      switch(other.getModelType())
-    //      {
-    //        case BVH_MODEL_TRIANGLES:
-    //          num_primitives = num_tris;
-    //          break;
-    //        case BVH_MODEL_POINTCLOUD:
-    //          num_primitives = num_vertices;
-    //          break;
-    //        default:
-    //          ;
-    //      }
-    //    }
-    //
-    //    if(num_primitives != other_num_primitives)
-    //      return false;
-    //
-    //    for(int k = 0; k < num_primitives; ++k)
-    //    {
-    //      if(primitive_indices[k] != other.primitive_indices[k])
-    //        return false;
-    //    }
-
-    if (num_bvs != other.num_bvs) return false;
-
-    if ((!(bvs.get()) && other.bvs.get()) || (bvs.get() && !(other.bvs.get())))
-      return false;
-    if (bvs.get() && other.bvs.get()) {
-      const bv_node_vector_t& bvs_ = *bvs;
-      const bv_node_vector_t& other_bvs_ = *(other.bvs);
-      for (unsigned int k = 0; k < num_bvs; ++k) {
-        if (bvs_[k] != other_bvs_[k]) return false;
-      }
-    }
-
+    COAL_EQUAL_OPERATOR_CHECK(Base::isEqual(_other));
+    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(bvs, other.bvs));
     return true;
   }
 };

--- a/include/coal/BVH/BVH_model.h
+++ b/include/coal/BVH/BVH_model.h
@@ -446,7 +446,7 @@ class COAL_DLLAPI BVHModel : public BVHModelBase {
     const BVHModel& other = *other_ptr;
 
     COAL_EQUAL_OPERATOR_CHECK(Base::isEqual(_other));
-    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(bvs, other.bvs));
+    COAL_EQUAL_OPERATOR_CHECK(shared_ptrs_are_equal(bvs, other.bvs));
     return true;
   }
 };

--- a/include/coal/collision.h
+++ b/include/coal/collision.h
@@ -85,7 +85,17 @@ class COAL_DLLAPI ComputeCollision {
                          CollisionResult& result) const;
 
   bool operator==(const ComputeCollision& other) const {
-    return o1 == other.o1 && o2 == other.o2 && solver == other.solver;
+    COAL_EQUAL_OPERATOR_CHECK(((o1 == nullptr && other.o1 == nullptr) ||
+                               (o1 != nullptr && other.o1 != nullptr)));
+    COAL_EQUAL_OPERATOR_CHECK(((o2 == nullptr && other.o2 == nullptr) ||
+                               (o2 != nullptr && other.o2 != nullptr)));
+    if ((o1 && other.o1) && (o1 != other.o1))
+      COAL_EQUAL_OPERATOR_CHECK(*o1 == *other.o1);
+    if ((o2 && other.o2) && (o2 != other.o2))
+      COAL_EQUAL_OPERATOR_CHECK(*o2 == *other.o2);
+    COAL_EQUAL_OPERATOR_CHECK(solver == other.solver);
+    COAL_EQUAL_OPERATOR_CHECK(func == other.func);
+    return true;
   }
 
   bool operator!=(const ComputeCollision& other) const {

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -331,23 +331,31 @@ struct COAL_DLLAPI QueryRequest {
 
   /// @brief whether two QueryRequest are the same or not
   inline bool operator==(const QueryRequest& other) const {
+    if (this == &other) return true;
+
     COAL_COMPILER_DIAGNOSTIC_PUSH
     COAL_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
-    return gjk_initial_guess == other.gjk_initial_guess &&
-           enable_cached_gjk_guess == other.enable_cached_gjk_guess &&
-           gjk_variant == other.gjk_variant &&
-           gjk_convergence_criterion == other.gjk_convergence_criterion &&
-           gjk_convergence_criterion_type ==
-               other.gjk_convergence_criterion_type &&
-           gjk_tolerance == other.gjk_tolerance &&
-           gjk_max_iterations == other.gjk_max_iterations &&
-           cached_gjk_guess == other.cached_gjk_guess &&
-           cached_support_func_guess == other.cached_support_func_guess &&
-           epa_max_iterations == other.epa_max_iterations &&
-           epa_tolerance == other.epa_tolerance &&
-           enable_timings == other.enable_timings &&
-           collision_distance_threshold == other.collision_distance_threshold;
+    COAL_EQUAL_OPERATOR_CHECK(gjk_initial_guess == other.gjk_initial_guess);
+    COAL_EQUAL_OPERATOR_CHECK(enable_cached_gjk_guess ==
+                              other.enable_cached_gjk_guess);
+    COAL_EQUAL_OPERATOR_CHECK(gjk_variant == other.gjk_variant);
+    COAL_EQUAL_OPERATOR_CHECK(gjk_convergence_criterion ==
+                              other.gjk_convergence_criterion);
+    COAL_EQUAL_OPERATOR_CHECK(gjk_convergence_criterion_type ==
+                              other.gjk_convergence_criterion_type);
+    COAL_EQUAL_OPERATOR_CHECK(gjk_tolerance == other.gjk_tolerance);
+    COAL_EQUAL_OPERATOR_CHECK(gjk_max_iterations == other.gjk_max_iterations);
+    COAL_EQUAL_OPERATOR_CHECK(cached_gjk_guess == other.cached_gjk_guess);
+    COAL_EQUAL_OPERATOR_CHECK(cached_support_func_guess ==
+                              other.cached_support_func_guess);
+    COAL_EQUAL_OPERATOR_CHECK(epa_max_iterations == other.epa_max_iterations);
+    COAL_EQUAL_OPERATOR_CHECK(epa_tolerance == other.epa_tolerance);
+    COAL_EQUAL_OPERATOR_CHECK(enable_timings == other.enable_timings);
+    COAL_EQUAL_OPERATOR_CHECK(collision_distance_threshold ==
+                              other.collision_distance_threshold);
     COAL_COMPILER_DIAGNOSTIC_POP
+
+    return true;
   }
 
   /// @brief whether two QueryRequest are different or not
@@ -503,16 +511,22 @@ struct COAL_DLLAPI CollisionRequest : QueryRequest {
 
   /// @brief whether two CollisionRequest are the same or not
   inline bool operator==(const CollisionRequest& other) const {
+    if (this == &other) return true;
+
     COAL_COMPILER_DIAGNOSTIC_PUSH
     COAL_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
-    return QueryRequest::operator==(other) &&
-           num_max_contacts == other.num_max_contacts &&
-           enable_contact == other.enable_contact &&
-           enable_distance_lower_bound == other.enable_distance_lower_bound &&
-           security_margin == other.security_margin &&
-           break_distance == other.break_distance &&
-           distance_upper_bound == other.distance_upper_bound;
+    COAL_EQUAL_OPERATOR_CHECK((QueryRequest::operator==(other)));
+    COAL_EQUAL_OPERATOR_CHECK(num_max_contacts == other.num_max_contacts);
+    COAL_EQUAL_OPERATOR_CHECK(enable_contact == other.enable_contact);
+    COAL_EQUAL_OPERATOR_CHECK(enable_distance_lower_bound ==
+                              other.enable_distance_lower_bound);
+    COAL_EQUAL_OPERATOR_CHECK(security_margin == other.security_margin);
+    COAL_EQUAL_OPERATOR_CHECK(break_distance == other.break_distance);
+    COAL_EQUAL_OPERATOR_CHECK(distance_upper_bound ==
+                              other.distance_upper_bound);
     COAL_COMPILER_DIAGNOSTIC_POP
+
+    return true;
   }
 
   /// @brief whether two CollisionRequest are different or not
@@ -629,11 +643,17 @@ struct COAL_DLLAPI CollisionResult : QueryResult {
 
   /// @brief whether two CollisionResult are the same or not
   inline bool operator==(const CollisionResult& other) const {
-    return contacts == other.contacts &&
-           distance_lower_bound == other.distance_lower_bound &&
-           nearest_points[0] == other.nearest_points[0] &&
-           nearest_points[1] == other.nearest_points[1] &&
-           normal == other.normal;
+    if (this == &other) return true;
+
+    COAL_EQUAL_OPERATOR_CHECK((QueryResult::operator==(other)));
+    COAL_EQUAL_OPERATOR_CHECK(contacts == other.contacts);
+    COAL_EQUAL_OPERATOR_CHECK(distance_lower_bound ==
+                              other.distance_lower_bound);
+    COAL_EQUAL_OPERATOR_CHECK(nearest_points[0] == other.nearest_points[0]);
+    COAL_EQUAL_OPERATOR_CHECK(nearest_points[1] == other.nearest_points[1]);
+    COAL_EQUAL_OPERATOR_CHECK(normal == other.normal);
+
+    return true;
   }
 
   /// @brief whether two CollisionResult are the same or not
@@ -898,9 +918,14 @@ struct COAL_DLLAPI ContactPatch {
   /// However, two contact patches can be identical, but have a different
   /// order for their points. Use `isEqual` in this case.
   bool operator==(const ContactPatch& other) const {
-    return this->tf == other.tf && this->direction == other.direction &&
-           this->penetration_depth == other.penetration_depth &&
-           this->points() == other.points();
+    if (this == &other) return true;
+
+    COAL_EQUAL_OPERATOR_CHECK(tf == other.tf);
+    COAL_EQUAL_OPERATOR_CHECK(direction == other.direction);
+    COAL_EQUAL_OPERATOR_CHECK(penetration_depth == other.penetration_depth);
+    COAL_EQUAL_OPERATOR_CHECK(points() == other.points());
+
+    return true;
   }
 
   /// @brief Whether two contact patches are different or not.
@@ -1090,10 +1115,14 @@ struct COAL_DLLAPI ContactPatchRequest {
 
   /// @brief Whether two ContactPatchRequest are identical or not.
   bool operator==(const ContactPatchRequest& other) const {
-    return this->max_num_patch == other.max_num_patch &&
-           this->getNumSamplesCurvedShapes() ==
-               other.getNumSamplesCurvedShapes() &&
-           this->getPatchTolerance() == other.getPatchTolerance();
+    if (this == &other) return true;
+
+    COAL_EQUAL_OPERATOR_CHECK(max_num_patch == other.max_num_patch);
+    COAL_EQUAL_OPERATOR_CHECK(getNumSamplesCurvedShapes() ==
+                              other.getNumSamplesCurvedShapes());
+    COAL_EQUAL_OPERATOR_CHECK(getPatchTolerance() == other.getPatchTolerance());
+
+    return true;
   }
 
   /// @brief Whether two ContactPatchRequest are different or not.
@@ -1293,16 +1322,14 @@ struct COAL_DLLAPI ContactPatchResult {
 
   /// @brief Whether two ContactPatchResult are identical or not.
   bool operator==(const ContactPatchResult& other) const {
-    if (this->numContactPatches() != other.numContactPatches()) {
-      return false;
-    }
+    if (this == &other) return true;
+
+    COAL_EQUAL_OPERATOR_CHECK(numContactPatches() == other.numContactPatches());
 
     for (size_t i = 0; i < this->numContactPatches(); ++i) {
       const ContactPatch& patch = this->getContactPatch(i);
       const ContactPatch& other_patch = other.getContactPatch(i);
-      if (!(patch == other_patch)) {
-        return false;
-      }
+      COAL_EQUAL_OPERATOR_CHECK(patch == other_patch);
     }
 
     return true;
@@ -1414,13 +1441,20 @@ struct COAL_DLLAPI DistanceRequest : QueryRequest {
 
   /// @brief whether two DistanceRequest are the same or not
   inline bool operator==(const DistanceRequest& other) const {
+    if (this == &other) return true;
+
     COAL_COMPILER_DIAGNOSTIC_PUSH
     COAL_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
-    return QueryRequest::operator==(other) &&
-           enable_nearest_points == other.enable_nearest_points &&
-           enable_signed_distance == other.enable_signed_distance &&
-           rel_err == other.rel_err && abs_err == other.abs_err;
+    COAL_EQUAL_OPERATOR_CHECK((QueryRequest::operator==(other)));
+    COAL_EQUAL_OPERATOR_CHECK(enable_nearest_points ==
+                              other.enable_nearest_points);
+    COAL_EQUAL_OPERATOR_CHECK(enable_signed_distance ==
+                              other.enable_signed_distance);
+    COAL_EQUAL_OPERATOR_CHECK(rel_err == other.rel_err);
+    COAL_EQUAL_OPERATOR_CHECK(abs_err == other.abs_err);
     COAL_COMPILER_DIAGNOSTIC_POP
+
+    return true;
   }
 
   /// @brief whether two DistanceRequest are different or not

--- a/include/coal/collision_object.h
+++ b/include/coal/collision_object.h
@@ -45,6 +45,7 @@
 #include "coal/fwd.hh"
 #include "coal/BV/AABB.h"
 #include "coal/math/transform.h"
+#include "coal/shared_ptr_comparison.h"
 
 namespace coal {
 
@@ -112,12 +113,14 @@ class COAL_DLLAPI CollisionGeometry {
 
   /// \brief Equality operator
   bool operator==(const CollisionGeometry& other) const {
-    return cost_density == other.cost_density &&
-           threshold_occupied == other.threshold_occupied &&
-           threshold_free == other.threshold_free &&
-           aabb_center == other.aabb_center &&
-           aabb_radius == other.aabb_radius && aabb_local == other.aabb_local &&
-           isEqual(other);
+    COAL_EQUAL_OPERATOR_CHECK(cost_density == other.cost_density);
+    COAL_EQUAL_OPERATOR_CHECK(threshold_occupied == other.threshold_occupied);
+    COAL_EQUAL_OPERATOR_CHECK(threshold_free == other.threshold_free);
+    COAL_EQUAL_OPERATOR_CHECK(aabb_center == other.aabb_center);
+    COAL_EQUAL_OPERATOR_CHECK(aabb_radius == other.aabb_radius);
+    COAL_EQUAL_OPERATOR_CHECK(aabb_local == other.aabb_local);
+    COAL_EQUAL_OPERATOR_CHECK(isEqual(other));
+    return true;
   }
 
   /// \brief Difference operator
@@ -235,7 +238,10 @@ class COAL_DLLAPI CollisionObject {
   }
 
   bool operator==(const CollisionObject& other) const {
-    return cgeom == other.cgeom && t == other.t && user_data == other.user_data;
+    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(cgeom, other.cgeom));
+    COAL_EQUAL_OPERATOR_CHECK(t == other.t);
+    COAL_EQUAL_OPERATOR_CHECK(user_data == other.user_data);
+    return true;
   }
 
   bool operator!=(const CollisionObject& other) const {

--- a/include/coal/collision_object.h
+++ b/include/coal/collision_object.h
@@ -238,7 +238,7 @@ class COAL_DLLAPI CollisionObject {
   }
 
   bool operator==(const CollisionObject& other) const {
-    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(cgeom, other.cgeom));
+    COAL_EQUAL_OPERATOR_CHECK(shared_ptrs_are_equal(cgeom, other.cgeom));
     COAL_EQUAL_OPERATOR_CHECK(t == other.t);
     COAL_EQUAL_OPERATOR_CHECK(user_data == other.user_data);
     return true;

--- a/include/coal/contact_patch.h
+++ b/include/coal/contact_patch.h
@@ -86,8 +86,18 @@ class COAL_DLLAPI ComputeContactPatch {
                   ContactPatchResult& result) const;
 
   bool operator==(const ComputeContactPatch& other) const {
-    return this->o1 == other.o1 && this->o2 == other.o2 &&
-           this->csolver == other.csolver;
+    COAL_EQUAL_OPERATOR_CHECK(((o1 == nullptr && other.o1 == nullptr) ||
+                               (o1 != nullptr && other.o1 != nullptr)));
+    COAL_EQUAL_OPERATOR_CHECK(((o2 == nullptr && other.o2 == nullptr) ||
+                               (o2 != nullptr && other.o2 != nullptr)));
+    if ((o1 && other.o1) && (o1 != other.o1))
+      COAL_EQUAL_OPERATOR_CHECK(*o1 == *other.o1);
+    if ((o2 && other.o2) && (o2 != other.o2))
+      COAL_EQUAL_OPERATOR_CHECK(*o2 == *other.o2);
+    COAL_EQUAL_OPERATOR_CHECK(csolver == other.csolver);
+    COAL_EQUAL_OPERATOR_CHECK(func == other.func);
+    COAL_EQUAL_OPERATOR_CHECK(swap_geoms == other.swap_geoms);
+    return true;
   }
 
   bool operator!=(const ComputeContactPatch& other) const {

--- a/include/coal/contact_patch/contact_patch_solver.h
+++ b/include/coal/contact_patch/contact_patch_solver.h
@@ -187,15 +187,22 @@ struct COAL_DLLAPI ContactPatchSolver {
       const ShapeBase* shape, ShapeSupportData& support_data);
 
   bool operator==(const ContactPatchSolver& other) const {
-    return this->num_samples_curved_shapes == other.num_samples_curved_shapes &&
-           this->patch_tolerance == other.patch_tolerance &&
-           this->support_guess == other.support_guess &&
-           this->support_set_shape1 == other.support_set_shape1 &&
-           this->support_set_shape2 == other.support_set_shape2 &&
-           this->support_set_buffer == other.support_set_buffer &&
-           this->added_to_patch == other.added_to_patch &&
-           this->supportFuncShape1 == other.supportFuncShape1 &&
-           this->supportFuncShape2 == other.supportFuncShape2;
+    COAL_EQUAL_OPERATOR_CHECK(this->num_samples_curved_shapes ==
+                              other.num_samples_curved_shapes);
+    COAL_EQUAL_OPERATOR_CHECK(this->patch_tolerance == other.patch_tolerance);
+    COAL_EQUAL_OPERATOR_CHECK(this->support_guess == other.support_guess);
+    COAL_EQUAL_OPERATOR_CHECK(this->support_set_shape1 ==
+                              other.support_set_shape1);
+    COAL_EQUAL_OPERATOR_CHECK(this->support_set_shape2 ==
+                              other.support_set_shape2);
+    COAL_EQUAL_OPERATOR_CHECK(this->support_set_buffer ==
+                              other.support_set_buffer);
+    COAL_EQUAL_OPERATOR_CHECK(this->added_to_patch == other.added_to_patch);
+    COAL_EQUAL_OPERATOR_CHECK(this->supportFuncShape1 ==
+                              other.supportFuncShape1);
+    COAL_EQUAL_OPERATOR_CHECK(this->supportFuncShape2 ==
+                              other.supportFuncShape2);
+    return true;
   }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/include/coal/data_types.h
+++ b/include/coal/data_types.h
@@ -44,6 +44,7 @@
 
 #include "coal/config.hh"
 #include "coal/deprecated.hh"
+#include "coal/fwd.hh"
 
 #ifdef COAL_HAS_OCTOMAP
 #define OCTOMAP_VERSION_AT_LEAST(x, y, z) \
@@ -181,8 +182,10 @@ class TriangleTpl {
   static inline size_type size() { return 3; }
 
   bool operator==(const TriangleTpl& other) const {
-    return vids[0] == other.vids[0] && vids[1] == other.vids[1] &&
-           vids[2] == other.vids[2];
+    COAL_EQUAL_OPERATOR_CHECK(vids[0] == other.vids[0]);
+    COAL_EQUAL_OPERATOR_CHECK(vids[1] == other.vids[1]);
+    COAL_EQUAL_OPERATOR_CHECK(vids[2] == other.vids[2]);
+    return true;
   }
 
   bool operator!=(const TriangleTpl& other) const { return !(*this == other); }
@@ -269,8 +272,11 @@ struct QuadrilateralTpl {
   static inline size_type size() { return 4; }
 
   bool operator==(const QuadrilateralTpl& other) const {
-    return vids[0] == other.vids[0] && vids[1] == other.vids[1] &&
-           vids[2] == other.vids[2] && vids[3] == other.vids[3];
+    COAL_EQUAL_OPERATOR_CHECK(vids[0] == other.vids[0]);
+    COAL_EQUAL_OPERATOR_CHECK(vids[1] == other.vids[1]);
+    COAL_EQUAL_OPERATOR_CHECK(vids[2] == other.vids[2]);
+    COAL_EQUAL_OPERATOR_CHECK(vids[3] == other.vids[3]);
+    return true;
   }
 
   bool operator!=(const QuadrilateralTpl& other) const {

--- a/include/coal/distance.h
+++ b/include/coal/distance.h
@@ -77,8 +77,18 @@ class COAL_DLLAPI ComputeDistance {
                     DistanceResult& result) const;
 
   bool operator==(const ComputeDistance& other) const {
-    return o1 == other.o1 && o2 == other.o2 && swap_geoms == other.swap_geoms &&
-           solver == other.solver && func == other.func;
+    COAL_EQUAL_OPERATOR_CHECK(((o1 == nullptr && other.o1 == nullptr) ||
+                               (o1 != nullptr && other.o1 != nullptr)));
+    COAL_EQUAL_OPERATOR_CHECK(((o2 == nullptr && other.o2 == nullptr) ||
+                               (o2 != nullptr && other.o2 != nullptr)));
+    if ((o1 && other.o1) && (o1 != other.o1))
+      COAL_EQUAL_OPERATOR_CHECK(*o1 == *other.o1);
+    if ((o2 && other.o2) && (o2 != other.o2))
+      COAL_EQUAL_OPERATOR_CHECK(*o2 == *other.o2);
+    COAL_EQUAL_OPERATOR_CHECK(swap_geoms == other.swap_geoms);
+    COAL_EQUAL_OPERATOR_CHECK(solver == other.solver);
+    COAL_EQUAL_OPERATOR_CHECK(func == other.func);
+    return true;
   }
 
   bool operator!=(const ComputeDistance& other) const {

--- a/include/coal/fwd.hh
+++ b/include/coal/fwd.hh
@@ -76,6 +76,9 @@
     COAL_THROW_PRETTY(message, exception);                  \
   }
 
+/// @brief Macro to be used in an equality operator and return false if the
+/// boolean is false. This is useful for debugging as this macro can be
+/// overridden to throw an exception, print a message etc.
 #ifndef COAL_EQUAL_OPERATOR_CHECK
 #define COAL_EQUAL_OPERATOR_CHECK(boolean) \
   if (!(boolean)) {                        \

--- a/include/coal/hfield.h
+++ b/include/coal/hfield.h
@@ -86,10 +86,15 @@ struct COAL_DLLAPI HFNodeBase {
 
   /// @brief Comparison operator
   bool operator==(const HFNodeBase& other) const {
-    return first_child == other.first_child && x_id == other.x_id &&
-           x_size == other.x_size && y_id == other.y_id &&
-           y_size == other.y_size && max_height == other.max_height &&
-           contact_active_faces == other.contact_active_faces;
+    COAL_EQUAL_OPERATOR_CHECK(first_child == other.first_child);
+    COAL_EQUAL_OPERATOR_CHECK(x_id == other.x_id);
+    COAL_EQUAL_OPERATOR_CHECK(x_size == other.x_size);
+    COAL_EQUAL_OPERATOR_CHECK(y_id == other.y_id);
+    COAL_EQUAL_OPERATOR_CHECK(y_size == other.y_size);
+    COAL_EQUAL_OPERATOR_CHECK(max_height == other.max_height);
+    COAL_EQUAL_OPERATOR_CHECK(contact_active_faces ==
+                              other.contact_active_faces);
+    return true;
   }
 
   /// @brief Difference operator
@@ -135,7 +140,9 @@ struct COAL_DLLAPI HFNode : public HFNodeBase {
 
   /// @brief Equality operator
   bool operator==(const HFNode& other) const {
-    return Base::operator==(other) && bv == other.bv;
+    COAL_EQUAL_OPERATOR_CHECK(Base::operator==(other));
+    COAL_EQUAL_OPERATOR_CHECK(bv == other.bv);
+    return true;
   }
 
   /// @brief Difference operator
@@ -503,11 +510,16 @@ class COAL_DLLAPI HeightField : public CollisionGeometry {
     if (other_ptr == nullptr) return false;
     const HeightField& other = *other_ptr;
 
-    return x_dim == other.x_dim && y_dim == other.y_dim &&
-           heights == other.heights && min_height == other.min_height &&
-           max_height == other.max_height && x_grid == other.x_grid &&
-           y_grid == other.y_grid && bvs == other.bvs &&
-           num_bvs == other.num_bvs;
+    COAL_EQUAL_OPERATOR_CHECK(x_dim == other.x_dim);
+    COAL_EQUAL_OPERATOR_CHECK(y_dim == other.y_dim);
+    COAL_EQUAL_OPERATOR_CHECK(heights == other.heights);
+    COAL_EQUAL_OPERATOR_CHECK(min_height == other.min_height);
+    COAL_EQUAL_OPERATOR_CHECK(max_height == other.max_height);
+    COAL_EQUAL_OPERATOR_CHECK(x_grid == other.x_grid);
+    COAL_EQUAL_OPERATOR_CHECK(y_grid == other.y_grid);
+    COAL_EQUAL_OPERATOR_CHECK(bvs == other.bvs);
+    COAL_EQUAL_OPERATOR_CHECK(num_bvs == other.num_bvs);
+    return true;
   }
 };
 

--- a/include/coal/math/transform.h
+++ b/include/coal/math/transform.h
@@ -212,7 +212,9 @@ class COAL_DLLAPI Transform3s {
 
   /// @brief Comparison operator
   bool operator==(const Transform3s& other) const {
-    return (R == other.getRotation()) && (T == other.getTranslation());
+    COAL_EQUAL_OPERATOR_CHECK(R == other.getRotation());
+    COAL_EQUAL_OPERATOR_CHECK(T == other.getTranslation());
+    return true;
   }
 
   /// @brief Comparison operator

--- a/include/coal/narrowphase/narrowphase.h
+++ b/include/coal/narrowphase/narrowphase.h
@@ -249,20 +249,27 @@ struct COAL_DLLAPI GJKSolver {
   COAL_COMPILER_DIAGNOSTIC_PUSH
   COAL_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
   bool operator==(const GJKSolver& other) const {
-    return this->enable_cached_guess ==
-               other.enable_cached_guess &&  // use gjk_initial_guess instead
-           this->cached_guess == other.cached_guess &&
-           this->support_func_cached_guess == other.support_func_cached_guess &&
-           this->gjk_max_iterations == other.gjk_max_iterations &&
-           this->gjk_tolerance == other.gjk_tolerance &&
-           this->distance_upper_bound == other.distance_upper_bound &&
-           this->gjk_variant == other.gjk_variant &&
-           this->gjk_convergence_criterion == other.gjk_convergence_criterion &&
-           this->gjk_convergence_criterion_type ==
-               other.gjk_convergence_criterion_type &&
-           this->gjk_initial_guess == other.gjk_initial_guess &&
-           this->epa_max_iterations == other.epa_max_iterations &&
-           this->epa_tolerance == other.epa_tolerance;
+    COAL_EQUAL_OPERATOR_CHECK(this->enable_cached_guess ==
+                              other.enable_cached_guess);
+    COAL_EQUAL_OPERATOR_CHECK(this->cached_guess == other.cached_guess);
+    COAL_EQUAL_OPERATOR_CHECK(this->support_func_cached_guess ==
+                              other.support_func_cached_guess);
+    COAL_EQUAL_OPERATOR_CHECK(this->gjk_max_iterations ==
+                              other.gjk_max_iterations);
+    COAL_EQUAL_OPERATOR_CHECK(this->gjk_tolerance == other.gjk_tolerance);
+    COAL_EQUAL_OPERATOR_CHECK(this->distance_upper_bound ==
+                              other.distance_upper_bound);
+    COAL_EQUAL_OPERATOR_CHECK(this->gjk_variant == other.gjk_variant);
+    COAL_EQUAL_OPERATOR_CHECK(this->gjk_convergence_criterion ==
+                              other.gjk_convergence_criterion);
+    COAL_EQUAL_OPERATOR_CHECK(this->gjk_convergence_criterion_type ==
+                              other.gjk_convergence_criterion_type);
+    COAL_EQUAL_OPERATOR_CHECK(this->gjk_initial_guess ==
+                              other.gjk_initial_guess);
+    COAL_EQUAL_OPERATOR_CHECK(this->epa_max_iterations ==
+                              other.epa_max_iterations);
+    COAL_EQUAL_OPERATOR_CHECK(this->epa_tolerance == other.epa_tolerance);
+    return true;
   }
   COAL_COMPILER_DIAGNOSTIC_POP
 

--- a/include/coal/octree.h
+++ b/include/coal/octree.h
@@ -270,10 +270,12 @@ class COAL_DLLAPI OcTree : public CollisionGeometry {
     if (other_ptr == nullptr) return false;
     const OcTree& other = *other_ptr;
 
-    return (tree.get() == other.tree.get() || toBoxes() == other.toBoxes()) &&
-           default_occupancy == other.default_occupancy &&
-           occupancy_threshold == other.occupancy_threshold &&
-           free_threshold == other.free_threshold;
+    COAL_EQUAL_OPERATOR_CHECK(tree.get() == other.tree.get() ||
+                              toBoxes() == other.toBoxes());
+    COAL_EQUAL_OPERATOR_CHECK(default_occupancy == other.default_occupancy);
+    COAL_EQUAL_OPERATOR_CHECK(occupancy_threshold == other.occupancy_threshold);
+    COAL_EQUAL_OPERATOR_CHECK(free_threshold == other.free_threshold);
+    return true;
   }
 
  public:

--- a/include/coal/shape/convex.h
+++ b/include/coal/shape/convex.h
@@ -149,6 +149,16 @@ class ConvexTpl : public ConvexBaseTpl<typename PolygonT::IndexType> {
                        ConvexTpl<OtherPolygonT>* copy);
 
   using Base::nneighbors_;
+
+ private:
+  virtual bool isEqual(const CollisionGeometry& _other) const override {
+    const ConvexTpl* other_ptr = dynamic_cast<const ConvexTpl*>(&_other);
+    if (other_ptr == nullptr) return false;
+    COAL_EQUAL_OPERATOR_CHECK(Base::isEqual(_other));
+    COAL_EQUAL_OPERATOR_CHECK(
+        compare_shared_ptr(polygons, other_ptr->polygons));
+    return true;
+  }
 };
 
 template <typename PolygonT>

--- a/include/coal/shape/convex.h
+++ b/include/coal/shape/convex.h
@@ -156,7 +156,7 @@ class ConvexTpl : public ConvexBaseTpl<typename PolygonT::IndexType> {
     if (other_ptr == nullptr) return false;
     COAL_EQUAL_OPERATOR_CHECK(Base::isEqual(_other));
     COAL_EQUAL_OPERATOR_CHECK(
-        compare_shared_ptr(polygons, other_ptr->polygons));
+        shared_ptrs_are_equal(polygons, other_ptr->polygons));
     return true;
   }
 };

--- a/include/coal/shape/geometric_shapes.h
+++ b/include/coal/shape/geometric_shapes.h
@@ -45,6 +45,7 @@
 
 #include "coal/collision_object.h"
 #include "coal/data_types.h"
+#include "coal/shared_ptr_comparison.h"
 
 #ifdef COAL_HAS_QHULL
 namespace orgQhull {
@@ -86,6 +87,17 @@ class COAL_DLLAPI ShapeBase : public CollisionGeometry {
   Scalar getSweptSphereRadius() const { return this->m_swept_sphere_radius; }
 
  protected:
+  bool isEqual(const CollisionGeometry& _other) const override {
+    const ShapeBase* other_ptr = dynamic_cast<const ShapeBase*>(&_other);
+    if (other_ptr == nullptr) return false;
+    const ShapeBase& other = *other_ptr;
+
+    COAL_EQUAL_OPERATOR_CHECK(getSweptSphereRadius() ==
+                              other.getSweptSphereRadius());
+
+    return true;
+  }
+
   /// \brief Radius of the sphere swept around the shape.
   /// Default value is 0.
   /// Note: this property differs from `inflated` method of certain
@@ -152,8 +164,12 @@ class COAL_DLLAPI TriangleP : public ShapeBase {
     if (other_ptr == nullptr) return false;
     const TriangleP& other = *other_ptr;
 
-    return a == other.a && b == other.b && c == other.c &&
-           getSweptSphereRadius() == other.getSweptSphereRadius();
+    COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
+    COAL_EQUAL_OPERATOR_CHECK(a == other.a);
+    COAL_EQUAL_OPERATOR_CHECK(b == other.b);
+    COAL_EQUAL_OPERATOR_CHECK(c == other.c);
+
+    return true;
   }
 
  public:
@@ -226,8 +242,10 @@ class COAL_DLLAPI Box : public ShapeBase {
     if (other_ptr == nullptr) return false;
     const Box& other = *other_ptr;
 
-    return halfSide == other.halfSide &&
-           getSweptSphereRadius() == other.getSweptSphereRadius();
+    COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
+    COAL_EQUAL_OPERATOR_CHECK(halfSide == other.halfSide);
+
+    return true;
   }
 
  public:
@@ -291,8 +309,10 @@ class COAL_DLLAPI Sphere : public ShapeBase {
     if (other_ptr == nullptr) return false;
     const Sphere& other = *other_ptr;
 
-    return radius == other.radius &&
-           getSweptSphereRadius() == other.getSweptSphereRadius();
+    COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
+    COAL_EQUAL_OPERATOR_CHECK(radius == other.radius);
+
+    return true;
   }
 
  public:
@@ -366,8 +386,10 @@ class COAL_DLLAPI Ellipsoid : public ShapeBase {
     if (other_ptr == nullptr) return false;
     const Ellipsoid& other = *other_ptr;
 
-    return radii == other.radii &&
-           getSweptSphereRadius() == other.getSweptSphereRadius();
+    COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
+    COAL_EQUAL_OPERATOR_CHECK(radii == other.radii);
+
+    return true;
   }
 
  public:
@@ -452,8 +474,11 @@ class COAL_DLLAPI Capsule : public ShapeBase {
     if (other_ptr == nullptr) return false;
     const Capsule& other = *other_ptr;
 
-    return radius == other.radius && halfLength == other.halfLength &&
-           getSweptSphereRadius() == other.getSweptSphereRadius();
+    COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
+    COAL_EQUAL_OPERATOR_CHECK(radius == other.radius);
+    COAL_EQUAL_OPERATOR_CHECK(halfLength == other.halfLength);
+
+    return true;
   }
 
  public:
@@ -545,8 +570,11 @@ class COAL_DLLAPI Cone : public ShapeBase {
     if (other_ptr == nullptr) return false;
     const Cone& other = *other_ptr;
 
-    return radius == other.radius && halfLength == other.halfLength &&
-           getSweptSphereRadius() == other.getSweptSphereRadius();
+    COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
+    COAL_EQUAL_OPERATOR_CHECK(radius == other.radius);
+    COAL_EQUAL_OPERATOR_CHECK(halfLength == other.halfLength);
+
+    return true;
   }
 
  public:
@@ -628,8 +656,11 @@ class COAL_DLLAPI Cylinder : public ShapeBase {
     if (other_ptr == nullptr) return false;
     const Cylinder& other = *other_ptr;
 
-    return radius == other.radius && halfLength == other.halfLength &&
-           getSweptSphereRadius() == other.getSweptSphereRadius();
+    COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
+    COAL_EQUAL_OPERATOR_CHECK(radius == other.radius);
+    COAL_EQUAL_OPERATOR_CHECK(halfLength == other.halfLength);
+
+    return true;
   }
 
  public:
@@ -644,9 +675,8 @@ struct ConvexBaseTplNeighbors {
   IndexType begin_id;
 
   bool operator==(const ConvexBaseTplNeighbors& other) const {
-    if (count != other.count) return false;
-    if (begin_id != other.begin_id) return false;
-
+    COAL_EQUAL_OPERATOR_CHECK(count == other.count);
+    COAL_EQUAL_OPERATOR_CHECK(begin_id == other.begin_id);
     return true;
   }
 
@@ -877,70 +907,21 @@ class ConvexBaseTpl : public ShapeBase {
     if (other_ptr == nullptr) return false;
     const ConvexBaseTpl& other = *other_ptr;
 
-    if (num_points != other.num_points) return false;
+    COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
+    COAL_EQUAL_OPERATOR_CHECK(num_points == other.num_points);
+    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(points, other.points));
+    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(neighbors, other.neighbors));
+    COAL_EQUAL_OPERATOR_CHECK(
+        compare_shared_ptr(nneighbors_, other.nneighbors_));
+    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(normals, other.normals));
+    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(offsets, other.offsets));
+    COAL_EQUAL_OPERATOR_CHECK(support_warm_starts.points ==
+                              other.support_warm_starts.points);
+    COAL_EQUAL_OPERATOR_CHECK(support_warm_starts.indices ==
+                              other.support_warm_starts.indices);
+    COAL_EQUAL_OPERATOR_CHECK(center == other.center);
 
-    if ((!(points.get()) && other.points.get()) ||
-        (points.get() && !(other.points.get())))
-      return false;
-    if (points.get() && other.points.get()) {
-      const std::vector<Vec3s>& points_ = *points;
-      const std::vector<Vec3s>& other_points_ = *(other.points);
-      for (unsigned int i = 0; i < num_points; ++i) {
-        if (points_[i] != (other_points_)[i]) return false;
-      }
-    }
-
-    if ((!(neighbors.get()) && other.neighbors.get()) ||
-        (neighbors.get() && !(other.neighbors.get())))
-      return false;
-    if (neighbors.get() && other.neighbors.get()) {
-      const std::vector<Neighbors>& neighbors_ = *neighbors;
-      const std::vector<Neighbors>& other_neighbors_ = *(other.neighbors);
-      for (unsigned int i = 0; i < num_points; ++i) {
-        if (neighbors_[i] != other_neighbors_[i]) return false;
-      }
-    }
-
-    if ((!(normals.get()) && other.normals.get()) ||
-        (normals.get() && !(other.normals.get())))
-      return false;
-    if (normals.get() && other.normals.get()) {
-      const std::vector<Vec3s>& normals_ = *normals;
-      const std::vector<Vec3s>& other_normals_ = *(other.normals);
-      for (unsigned int i = 0; i < num_normals_and_offsets; ++i) {
-        if (normals_[i] != other_normals_[i]) return false;
-      }
-    }
-
-    if ((!(offsets.get()) && other.offsets.get()) ||
-        (offsets.get() && !(other.offsets.get())))
-      return false;
-    if (offsets.get() && other.offsets.get()) {
-      const std::vector<Scalar>& offsets_ = *offsets;
-      const std::vector<Scalar>& other_offsets_ = *(other.offsets);
-      for (unsigned int i = 0; i < num_normals_and_offsets; ++i) {
-        if (offsets_[i] != other_offsets_[i]) return false;
-      }
-    }
-
-    if (this->support_warm_starts.points.size() !=
-            other.support_warm_starts.points.size() ||
-        this->support_warm_starts.indices.size() !=
-            other.support_warm_starts.indices.size()) {
-      return false;
-    }
-
-    for (size_t i = 0; i < this->support_warm_starts.points.size(); ++i) {
-      if (this->support_warm_starts.points[i] !=
-              other.support_warm_starts.points[i] ||
-          this->support_warm_starts.indices[i] !=
-              other.support_warm_starts.indices[i]) {
-        return false;
-      }
-    }
-
-    return center == other.center &&
-           getSweptSphereRadius() == other.getSweptSphereRadius();
+    return true;
   }
 
  public:
@@ -1042,8 +1023,11 @@ class COAL_DLLAPI Halfspace : public ShapeBase {
     if (other_ptr == nullptr) return false;
     const Halfspace& other = *other_ptr;
 
-    return n == other.n && d == other.d &&
-           getSweptSphereRadius() == other.getSweptSphereRadius();
+    COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
+    COAL_EQUAL_OPERATOR_CHECK(n == other.n);
+    COAL_EQUAL_OPERATOR_CHECK(d == other.d);
+
+    return true;
   }
 
  public:
@@ -1119,8 +1103,11 @@ class COAL_DLLAPI Plane : public ShapeBase {
     if (other_ptr == nullptr) return false;
     const Plane& other = *other_ptr;
 
-    return n == other.n && d == other.d &&
-           getSweptSphereRadius() == other.getSweptSphereRadius();
+    COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
+    COAL_EQUAL_OPERATOR_CHECK(n == other.n);
+    COAL_EQUAL_OPERATOR_CHECK(d == other.d);
+
+    return true;
   }
 
  public:

--- a/include/coal/shape/geometric_shapes.h
+++ b/include/coal/shape/geometric_shapes.h
@@ -909,12 +909,13 @@ class ConvexBaseTpl : public ShapeBase {
 
     COAL_EQUAL_OPERATOR_CHECK(ShapeBase::isEqual(other));
     COAL_EQUAL_OPERATOR_CHECK(num_points == other.num_points);
-    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(points, other.points));
-    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(neighbors, other.neighbors));
+    COAL_EQUAL_OPERATOR_CHECK(shared_ptrs_are_equal(points, other.points));
     COAL_EQUAL_OPERATOR_CHECK(
-        compare_shared_ptr(nneighbors_, other.nneighbors_));
-    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(normals, other.normals));
-    COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(offsets, other.offsets));
+        shared_ptrs_are_equal(neighbors, other.neighbors));
+    COAL_EQUAL_OPERATOR_CHECK(
+        shared_ptrs_are_equal(nneighbors_, other.nneighbors_));
+    COAL_EQUAL_OPERATOR_CHECK(shared_ptrs_are_equal(normals, other.normals));
+    COAL_EQUAL_OPERATOR_CHECK(shared_ptrs_are_equal(offsets, other.offsets));
     COAL_EQUAL_OPERATOR_CHECK(support_warm_starts.points ==
                               other.support_warm_starts.points);
     COAL_EQUAL_OPERATOR_CHECK(support_warm_starts.indices ==

--- a/include/coal/shared_ptr_comparison.h
+++ b/include/coal/shared_ptr_comparison.h
@@ -44,8 +44,8 @@ namespace coal {
 /// Returns true if both are null, both point to the same object,
 /// or both are non-null and their pointees compare equal.
 template <typename T>
-bool compare_shared_ptr(const std::shared_ptr<T>& ptr1,
-                        const std::shared_ptr<T>& ptr2) {
+bool shared_ptrs_are_equal(const std::shared_ptr<T>& ptr1,
+                           const std::shared_ptr<T>& ptr2) {
   if (ptr1 == ptr2) return true;
   if (ptr1 && ptr2) return *ptr1 == *ptr2;
   return false;

--- a/include/coal/shared_ptr_comparison.h
+++ b/include/coal/shared_ptr_comparison.h
@@ -1,0 +1,56 @@
+//
+// Software License Agreement (BSD License)
+//
+//  Copyright (c) 2026, Inria
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions
+//  are met:
+//
+//   * Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above
+//     copyright notice, this list of conditions and the following
+//     disclaimer in the documentation and/or other materials provided
+//     with the distribution.
+//   * Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived
+//     from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+//  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+//  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef COAL_SHARED_PTR_COMPARISON_H
+#define COAL_SHARED_PTR_COMPARISON_H
+
+#include <memory>
+
+// The content of this file is adapted from Pinocchio.
+
+namespace coal {
+
+/// @brief Compares two std::shared_ptr by value.
+/// Returns true if both are null, both point to the same object,
+/// or both are non-null and their pointees compare equal.
+template <typename T>
+bool compare_shared_ptr(const std::shared_ptr<T>& ptr1,
+                        const std::shared_ptr<T>& ptr2) {
+  if (ptr1 == ptr2) return true;
+  if (ptr1 && ptr2) return *ptr1 == *ptr2;
+  return false;
+}
+
+}  // namespace coal
+
+#endif  // COAL_SHARED_PTR_COMPARISON_H

--- a/src/BVH/BVH_model.cpp
+++ b/src/BVH/BVH_model.cpp
@@ -86,10 +86,11 @@ bool BVHModelBase::isEqual(const CollisionGeometry& _other) const {
   if (other_ptr == nullptr) return false;
   const BVHModelBase& other = *other_ptr;
 
-  COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(tri_indices, other.tri_indices));
-  COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(vertices, other.vertices));
   COAL_EQUAL_OPERATOR_CHECK(
-      compare_shared_ptr(prev_vertices, other.prev_vertices));
+      shared_ptrs_are_equal(tri_indices, other.tri_indices));
+  COAL_EQUAL_OPERATOR_CHECK(shared_ptrs_are_equal(vertices, other.vertices));
+  COAL_EQUAL_OPERATOR_CHECK(
+      shared_ptrs_are_equal(prev_vertices, other.prev_vertices));
   return true;
 }
 

--- a/src/BVH/BVH_model.cpp
+++ b/src/BVH/BVH_model.cpp
@@ -86,42 +86,10 @@ bool BVHModelBase::isEqual(const CollisionGeometry& _other) const {
   if (other_ptr == nullptr) return false;
   const BVHModelBase& other = *other_ptr;
 
-  bool result =
-      num_tris == other.num_tris && num_vertices == other.num_vertices;
-
-  if (!result) return false;
-
-  if ((!(tri_indices.get()) && other.tri_indices.get()) ||
-      (tri_indices.get() && !(other.tri_indices.get())))
-    return false;
-  if (tri_indices.get() && other.tri_indices.get()) {
-    const std::vector<Triangle32>& tri_indices_ = *(tri_indices);
-    const std::vector<Triangle32>& other_tri_indices_ = *(other.tri_indices);
-    for (size_t k = 0; k < static_cast<size_t>(num_tris); ++k)
-      if (tri_indices_[k] != other_tri_indices_[k]) return false;
-  }
-
-  if ((!(vertices.get()) && other.vertices.get()) ||
-      (vertices.get() && !(other.vertices.get())))
-    return false;
-  if (vertices.get() && other.vertices.get()) {
-    const std::vector<Vec3s>& vertices_ = *(vertices);
-    const std::vector<Vec3s>& other_vertices_ = *(other.vertices);
-    for (size_t k = 0; k < static_cast<size_t>(num_vertices); ++k)
-      if (vertices_[k] != other_vertices_[k]) return false;
-  }
-
-  if ((!(prev_vertices.get()) && other.prev_vertices.get()) ||
-      (prev_vertices.get() && !(other.prev_vertices.get())))
-    return false;
-  if (prev_vertices.get() && other.prev_vertices.get()) {
-    const std::vector<Vec3s>& prev_vertices_ = *(prev_vertices);
-    const std::vector<Vec3s>& other_prev_vertices_ = *(other.prev_vertices);
-    for (size_t k = 0; k < static_cast<size_t>(num_vertices); ++k) {
-      if (prev_vertices_[k] != other_prev_vertices_[k]) return false;
-    }
-  }
-
+  COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(tri_indices, other.tri_indices));
+  COAL_EQUAL_OPERATOR_CHECK(compare_shared_ptr(vertices, other.vertices));
+  COAL_EQUAL_OPERATOR_CHECK(
+      compare_shared_ptr(prev_vertices, other.prev_vertices));
   return true;
 }
 

--- a/src/broadphase/broadphase_SaP.cpp
+++ b/src/broadphase/broadphase_SaP.cpp
@@ -840,7 +840,9 @@ SaPCollisionManager::SaPPair::SaPPair(CollisionObject* a, CollisionObject* b) {
 
 //==============================================================================
 bool SaPCollisionManager::SaPPair::operator==(const SaPPair& other) const {
-  return ((obj1 == other.obj1) && (obj2 == other.obj2));
+  COAL_EQUAL_OPERATOR_CHECK(obj1 == other.obj1);
+  COAL_EQUAL_OPERATOR_CHECK(obj2 == other.obj2);
+  return true;
 }
 
 //==============================================================================


### PR DESCRIPTION
Added the COAL_EQUAL_OPERATOR_CHECK macro.

It can be overriden at compile time:
```bash
[compile command] -include iostream `-DCOAL_EQUAL_OPERATOR_CHECK(x)=do{if(!(x)){std::cout << \"[WARNING: ] Coal equality check for \" << \#x << \" failed\\n\";return false;};}while(0)`
```

Found it **very** practical when debugging serialization for example.