### PR TITLE
Improve pixi build version management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Project is now tested with Python 3.10 and 3.14
   - Python 3.10 is the minimal supported Python version
 - Nix: switch to flakoboros ([#852](https://github.com/coal-library/coal/pull/852))
+- Allow to use Python variant in pixi build ([#872](https://github.com/coal-library/coal/pull/872))
 
 ## [3.0.4] - 2026-06-29
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ name = { workspace = true }
 version = { workspace = true }
 
 [package.build]
-backend = { name = "pixi-build-cmake", version = "0.3.*" }
+backend = { name = "pixi-build-cmake", version = "*" }
 
 [package.build.config]
 extra-args = [
@@ -66,7 +66,7 @@ eigen = ">=3.4.0"
 eigen-abi-devel = ">=3.4.0"
 assimp = ">=5.4"
 numpy = ">=1.22.0"
-python = ">=3.9.0"
+python = "*"
 eigenpy = ">=3.7.0"
 octomap = ">=1.10"
 


### PR DESCRIPTION
To allow consumer to use variant, we should use "*" as a version range