### PR TITLE
Fix specialized shape to shape min distance update and enable_signed_distance flag 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Boost::thread
 
 ### Fixed
+- Specialized shape-shape distance functions (sphere/capsule/plane/halfspace/triangle pairs) now merge into `DistanceResult` with min semantics (`DistanceResult::update`) instead of overwriting `min_distance`. Broadphase distance queries mixing specialized and GJK pairs previously returned the last evaluated pair instead of the closest one ([#XXX](https://github.com/coal-library/coal/pull/XXX))
 - Fix doc parsing via doxygen scripts ([#678](https://github.com/coal-library/coal/pull/678) [#699](https://github.com/coal-library/coal/pull/699))
 - Correctly calculate AABB for pruned octrees ([#741](https://github.com/coal-library/coal/pull/741))
 - Fix contact counting in octree collision detection with ShapeShapeCollide ([#746](https://github.com/coal-library/coal/pull/746))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Boost::thread
 
 ### Fixed
-- Specialized shape-shape distance functions (sphere/capsule/plane/halfspace/triangle pairs) now merge into `DistanceResult` with min semantics (`DistanceResult::update`) instead of overwriting `min_distance`. Broadphase distance queries mixing specialized and GJK pairs previously returned the last evaluated pair instead of the closest one ([#XXX](https://github.com/coal-library/coal/pull/XXX))
-- Specialized shape-shape distance functions now honor `DistanceRequest::enable_signed_distance` (previously they always returned the signed distance, so `min_distance` could be negative with the flag off) ([#XXX](https://github.com/coal-library/coal/pull/XXX))
+- Specialized shape-shape distance functions (sphere/capsule/plane/halfspace/triangle pairs) now merge into `DistanceResult` with min semantics (`DistanceResult::update`) instead of overwriting `min_distance`. Broadphase distance queries mixing specialized and GJK pairs previously returned the last evaluated pair instead of the closest one ([#885](https://github.com/coal-library/coal/pull/885))
+- Specialized shape-shape distance functions now honor `DistanceRequest::enable_signed_distance` (previously they always returned the signed distance, so `min_distance` could be negative with the flag off) ([#885](https://github.com/coal-library/coal/pull/885))
 - Fix doc parsing via doxygen scripts ([#678](https://github.com/coal-library/coal/pull/678) [#699](https://github.com/coal-library/coal/pull/699))
 - Correctly calculate AABB for pruned octrees ([#741](https://github.com/coal-library/coal/pull/741))
 - Fix contact counting in octree collision detection with ShapeShapeCollide ([#746](https://github.com/coal-library/coal/pull/746))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Specialized shape-shape distance functions (sphere/capsule/plane/halfspace/triangle pairs) now merge into `DistanceResult` with min semantics (`DistanceResult::update`) instead of overwriting `min_distance`. Broadphase distance queries mixing specialized and GJK pairs previously returned the last evaluated pair instead of the closest one ([#XXX](https://github.com/coal-library/coal/pull/XXX))
+- Specialized shape-shape distance functions now honor `DistanceRequest::enable_signed_distance` (previously they always returned the signed distance, so `min_distance` could be negative with the flag off) ([#XXX](https://github.com/coal-library/coal/pull/XXX))
 - Fix doc parsing via doxygen scripts ([#678](https://github.com/coal-library/coal/pull/678) [#699](https://github.com/coal-library/coal/pull/699))
 - Correctly calculate AABB for pruned octrees ([#741](https://github.com/coal-library/coal/pull/741))
 - Fix contact counting in octree collision detection with ShapeShapeCollide ([#746](https://github.com/coal-library/coal/pull/746))

--- a/include/coal/internal/shape_shape_func.h
+++ b/include/coal/internal/shape_shape_func.h
@@ -40,6 +40,8 @@
 
 /// @cond INTERNAL
 
+#include <algorithm>
+
 #include "coal/collision_data.h"
 #include "coal/collision_utility.h"
 #include "coal/narrowphase/narrowphase.h"
@@ -233,9 +235,11 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
       DistanceResult& result) {                                                \
     if (request.isSatisfied(result)) return result.min_distance;               \
     Vec3s p1, p2, normal;                                                      \
-    const Scalar distance = internal::ShapeShapeDistance<T1, T2>(              \
+    Scalar distance = internal::ShapeShapeDistance<T1, T2>(                    \
         o1, tf1, o2, tf2, nsolver, request.enable_signed_distance, p1, p2,     \
         normal);                                                               \
+    if (!request.enable_signed_distance)                                       \
+      distance = (std::max)(distance, Scalar(0));                              \
     result.update(distance, o1, o2, DistanceResult::NONE,                      \
                   DistanceResult::NONE, p1, p2, normal);                       \
     return distance;                                                           \
@@ -248,9 +252,11 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
       DistanceResult& result) {                                                \
     if (request.isSatisfied(result)) return result.min_distance;               \
     Vec3s p1, p2, normal;                                                      \
-    const Scalar distance = internal::ShapeShapeDistance<T2, T1>(              \
+    Scalar distance = internal::ShapeShapeDistance<T2, T1>(                    \
         o1, tf1, o2, tf2, nsolver, request.enable_signed_distance, p1, p2,     \
         normal);                                                               \
+    if (!request.enable_signed_distance)                                       \
+      distance = (std::max)(distance, Scalar(0));                              \
     result.update(distance, o1, o2, DistanceResult::NONE,                      \
                   DistanceResult::NONE, p1, p2, normal);                       \
     return distance;                                                           \
@@ -271,9 +277,11 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
       DistanceResult& result) {                                                \
     if (request.isSatisfied(result)) return result.min_distance;               \
     Vec3s p1, p2, normal;                                                      \
-    const Scalar distance = internal::ShapeShapeDistance<T, T>(                \
+    Scalar distance = internal::ShapeShapeDistance<T, T>(                      \
         o1, tf1, o2, tf2, nsolver, request.enable_signed_distance, p1, p2,     \
         normal);                                                               \
+    if (!request.enable_signed_distance)                                       \
+      distance = (std::max)(distance, Scalar(0));                              \
     result.update(distance, o1, o2, DistanceResult::NONE,                      \
                   DistanceResult::NONE, p1, p2, normal);                       \
     return distance;                                                           \

--- a/include/coal/internal/shape_shape_func.h
+++ b/include/coal/internal/shape_shape_func.h
@@ -231,14 +231,14 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
       const CollisionGeometry* o2, const Transform3s& tf2,                     \
       const GJKSolver* nsolver, const DistanceRequest& request,                \
       DistanceResult& result) {                                                \
-    result.o1 = o1;                                                            \
-    result.o2 = o2;                                                            \
-    result.b1 = DistanceResult::NONE;                                          \
-    result.b2 = DistanceResult::NONE;                                          \
-    result.min_distance = internal::ShapeShapeDistance<T1, T2>(                \
-        o1, tf1, o2, tf2, nsolver, request.enable_signed_distance,             \
-        result.nearest_points[0], result.nearest_points[1], result.normal);    \
-    return result.min_distance;                                                \
+    if (request.isSatisfied(result)) return result.min_distance;               \
+    Vec3s p1, p2, normal;                                                      \
+    const Scalar distance = internal::ShapeShapeDistance<T1, T2>(              \
+        o1, tf1, o2, tf2, nsolver, request.enable_signed_distance, p1, p2,     \
+        normal);                                                               \
+    result.update(distance, o1, o2, DistanceResult::NONE,                      \
+                  DistanceResult::NONE, p1, p2, normal);                       \
+    return distance;                                                           \
   }                                                                            \
   template <>                                                                  \
   inline COAL_DLLAPI Scalar ShapeShapeDistance<T2, T1>(                        \
@@ -246,14 +246,14 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
       const CollisionGeometry* o2, const Transform3s& tf2,                     \
       const GJKSolver* nsolver, const DistanceRequest& request,                \
       DistanceResult& result) {                                                \
-    result.o1 = o1;                                                            \
-    result.o2 = o2;                                                            \
-    result.b1 = DistanceResult::NONE;                                          \
-    result.b2 = DistanceResult::NONE;                                          \
-    result.min_distance = internal::ShapeShapeDistance<T2, T1>(                \
-        o1, tf1, o2, tf2, nsolver, request.enable_signed_distance,             \
-        result.nearest_points[0], result.nearest_points[1], result.normal);    \
-    return result.min_distance;                                                \
+    if (request.isSatisfied(result)) return result.min_distance;               \
+    Vec3s p1, p2, normal;                                                      \
+    const Scalar distance = internal::ShapeShapeDistance<T2, T1>(              \
+        o1, tf1, o2, tf2, nsolver, request.enable_signed_distance, p1, p2,     \
+        normal);                                                               \
+    result.update(distance, o1, o2, DistanceResult::NONE,                      \
+                  DistanceResult::NONE, p1, p2, normal);                       \
+    return distance;                                                           \
   }
 
 #define SHAPE_SELF_DISTANCE_SPECIALIZATION(T)                                  \
@@ -269,14 +269,14 @@ std::size_t ShapeShapeCollide(const CollisionGeometry* o1,
       const CollisionGeometry* o2, const Transform3s& tf2,                     \
       const GJKSolver* nsolver, const DistanceRequest& request,                \
       DistanceResult& result) {                                                \
-    result.o1 = o1;                                                            \
-    result.o2 = o2;                                                            \
-    result.b1 = DistanceResult::NONE;                                          \
-    result.b2 = DistanceResult::NONE;                                          \
-    result.min_distance = internal::ShapeShapeDistance<T, T>(                  \
-        o1, tf1, o2, tf2, nsolver, request.enable_signed_distance,             \
-        result.nearest_points[0], result.nearest_points[1], result.normal);    \
-    return result.min_distance;                                                \
+    if (request.isSatisfied(result)) return result.min_distance;               \
+    Vec3s p1, p2, normal;                                                      \
+    const Scalar distance = internal::ShapeShapeDistance<T, T>(                \
+        o1, tf1, o2, tf2, nsolver, request.enable_signed_distance, p1, p2,     \
+        normal);                                                               \
+    result.update(distance, o1, o2, DistanceResult::NONE,                      \
+                  DistanceResult::NONE, p1, p2, normal);                       \
+    return distance;                                                           \
   }
 
 SHAPE_SHAPE_DISTANCE_SPECIALIZATION(Box, Halfspace)

--- a/test/broadphase_dynamic_AABB_tree.cpp
+++ b/test/broadphase_dynamic_AABB_tree.cpp
@@ -42,9 +42,12 @@
 // #include "coal/data_types.h"
 #include "coal/shape/geometric_shapes.h"
 #include "coal/broadphase/broadphase_dynamic_AABB_tree.h"
+#include "coal/broadphase/default_broadphase_callbacks.h"
+#include "coal/distance.h"
 
 #include <iostream>
 #include <memory>
+#include <random>
 
 using namespace coal;
 
@@ -140,4 +143,87 @@ BOOST_AUTO_TEST_CASE(DynamicAABBTreeCollisionManager_class) {
     dynamic_tree.update();
     dynamic_tree.distance(&callback);
   }
+}
+
+// Specialized (non-GJK) shape pairs must merge into a shared DistanceResult
+// with the same min semantics as the GJK path (DistanceResult::update).
+BOOST_AUTO_TEST_CASE(specialized_shape_distance_keeps_minimum) {
+  const Box box(0.2, 0.2, 0.2);
+  const Sphere sphere(0.05);
+  const Transform3s identity;
+  Transform3s tf_near;
+  tf_near.setTranslation(Vec3s(0.3, 0., 0.));
+  Transform3s tf_far;
+  tf_far.setTranslation(Vec3s(1., 0., 0.));
+
+  DistanceRequest request;
+  DistanceResult result;
+  const Scalar d_near =
+      distance(&box, identity, &sphere, tf_near, request, result);
+  const Vec3s p_near0 = result.nearest_points[0];
+  const Vec3s p_near1 = result.nearest_points[1];
+  const Scalar d_far =
+      distance(&box, identity, &sphere, tf_far, request, result);
+
+  BOOST_CHECK_CLOSE(d_near, 0.15, 1e-6);
+  BOOST_CHECK_CLOSE(d_far, 0.85, 1e-6);
+  BOOST_CHECK_EQUAL(result.min_distance, d_near);
+  BOOST_CHECK(result.nearest_points[0] == p_near0);
+  BOOST_CHECK(result.nearest_points[1] == p_near1);
+}
+
+// Broadphase distance over a mix of specialized (sphere-box, sphere-capsule)
+// and GJK (capsule-box) pairs must return the pairwise minimum.
+BOOST_AUTO_TEST_CASE(
+    DynamicAABBTreeCollisionManager_distance_specialized_pairs) {
+  std::vector<CollisionObjectPtr_t> objs1, objs2;
+  for (int i = 0; i < 4; ++i)
+    objs1.push_back(
+        std::make_shared<CollisionObject>(std::make_shared<Sphere>(0.05)));
+  for (int i = 0; i < 4; ++i)
+    objs1.push_back(std::make_shared<CollisionObject>(
+        std::make_shared<Capsule>(0.04, 0.2)));
+  for (int i = 0; i < 6; ++i)
+    objs2.push_back(std::make_shared<CollisionObject>(
+        std::make_shared<Box>(0.3, 0.3, 0.3)));
+
+  DynamicAABBTreeCollisionManager m1, m2;
+  for (const auto& o : objs1) m1.registerObject(o.get());
+  for (const auto& o : objs2) m2.registerObject(o.get());
+  m1.setup();
+  m2.setup();
+
+  std::mt19937 gen(0);
+  std::uniform_real_distribution<Scalar> uni(-1., 1.);
+  const DistanceRequest request;
+  int n_checked = 0;
+  for (int trial = 0; trial < 300; ++trial) {
+    for (const auto& o : objs1)
+      o->setTranslation(Vec3s(uni(gen), uni(gen), uni(gen)));
+    for (const auto& o : objs2)
+      o->setTranslation(Vec3s(uni(gen), uni(gen), uni(gen)));
+    m1.update();
+    m2.update();
+
+    DistanceResult pairwise;
+    for (const auto& a : objs1)
+      for (const auto& b : objs2) {
+        DistanceResult r;
+        distance(a.get(), b.get(), request, r);
+        pairwise.update(r);
+      }
+    if (pairwise.min_distance <= 0) continue;  // broadphase stops on contact
+    ++n_checked;
+
+    DistanceCallBackDefault callback;
+    m1.distance(&m2, &callback);
+    const DistanceResult& res = callback.data.result;
+    BOOST_CHECK_CLOSE(res.min_distance, pairwise.min_distance, 1e-6);
+    BOOST_CHECK_EQUAL(res.o1, pairwise.o1);
+    BOOST_CHECK_EQUAL(res.o2, pairwise.o2);
+    BOOST_CHECK_SMALL((res.nearest_points[0] - res.nearest_points[1]).norm() -
+                          pairwise.min_distance,
+                      Scalar(1e-6));
+  }
+  BOOST_CHECK(n_checked > 100);
 }

--- a/test/broadphase_dynamic_AABB_tree.cpp
+++ b/test/broadphase_dynamic_AABB_tree.cpp
@@ -227,3 +227,27 @@ BOOST_AUTO_TEST_CASE(
   }
   BOOST_CHECK(n_checked > 100);
 }
+
+// Specialized shape pairs must honor DistanceRequest::enable_signed_distance:
+// when it is off, min_distance is never negative.
+BOOST_AUTO_TEST_CASE(specialized_shape_distance_unsigned) {
+  const Box box(0.2, 0.2, 0.2);
+  const Sphere sphere(0.1);
+  const Transform3s identity;
+  Transform3s tf_penetrating;
+  tf_penetrating.setTranslation(Vec3s(0.15, 0., 0.));
+
+  DistanceRequest signed_request;
+  DistanceResult signed_result;
+  distance(&box, identity, &sphere, tf_penetrating, signed_request,
+           signed_result);
+  BOOST_CHECK_CLOSE(signed_result.min_distance, -0.05, 1e-6);
+
+  DistanceRequest unsigned_request;
+  unsigned_request.enable_signed_distance = false;
+  DistanceResult unsigned_result;
+  const Scalar d = distance(&box, identity, &sphere, tf_penetrating,
+                            unsigned_request, unsigned_result);
+  BOOST_CHECK_EQUAL(d, Scalar(0));
+  BOOST_CHECK_EQUAL(unsigned_result.min_distance, Scalar(0));
+}


### PR DESCRIPTION
Fixes two issues:
- The SHAPE_SHAPE_DISTANCE_SPECIALIZATION / SHAPE_SELF_DISTANCE_SPECIALIZATION wrappers assigned `result.min_distance` (and o1/o2/nearest_points/normal) unconditionally, while the generic ShapeShapeDistancer path checks `request.isSatisfied` and merges through `DistanceResult::update`. When a DistanceResult is shared across several pairs (e.g., broadphase checks) a specialized pair evaluated after a closer pair overwrote the minimum, so the query returned the last evaluated pair instead of the closest one. Fix is to merge with `DistanceResult::update`, like the generic path does; added regression test for this behavior as well.
- Analytic distance functions in src/distance ignore the `compute_signed_distance` argument, so with `DistanceRequest::enable_signed_distance = false` a specialized pair could still report a negative min_distance (different from documentation/GJK path). Fix is to clamp the result at zero; the witness points and normal are unchanged.