### PR TITLE
Replace undefined pointer arithmetic in octree b1/b2 with a node handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - If the `o1/o2` pointers are different, we check whether or not the underlying geometries are the same. This is typically important in the context of serialization.
   - Fix using NaN to initialize collision data (`Contact`, `CollisionResult`, `DistanceResult`). This prevents the absurd `Contact contact; contact == contact; // false` problem.
   - Fix NaNs coming from GJK/EPA when the algorithms (correctly) early stopped. NaNs indicate failure. In the case that GJK/EPA early stopped but ran fine, we set non-computed data to inf instead of NaN.
+- Octree contacts no longer report an undefined-behaviour `b1`/`b2`. The value was computed as `node - tree->getRoot()`, a pointer subtraction between two unrelated heap allocations, so it was undefined behaviour and could be an arbitrary signed offset. Octree contacts and distance results now report `coal::octreeNodeHandle`, a well-defined non-negative handle with the same meaning the field has carried since the node pointer was folded into `Contact`: unique per node and stable while the node lives, but not a cell index ([#886](https://github.com/coal-library/coal/pull/886))
 
 ### Changed
 - Float precision ([#665](https://github.com/coal-library/coal/pull/665))

--- a/include/coal/collision_data.h
+++ b/include/coal/collision_data.h
@@ -66,13 +66,15 @@ struct COAL_DLLAPI Contact {
   /// @brief contact primitive in object 1
   /// if object 1 is mesh or point cloud, it is the triangle or point id
   /// if object 1 is geometry shape, it is NONE (-1),
-  /// if object 1 is octree, it is the id of the cell
+  /// if object 1 is octree, it is a node handle, see
+  /// @ref coal::octreeNodeHandle
   int b1;
 
   /// @brief contact primitive in object 2
   /// if object 2 is mesh or point cloud, it is the triangle or point id
   /// if object 2 is geometry shape, it is NONE (-1),
-  /// if object 2 is octree, it is the id of the cell
+  /// if object 2 is octree, it is a node handle, see
+  /// @ref coal::octreeNodeHandle
   int b2;
 
   /// @brief contact normal, pointing from o1 to o2.
@@ -1509,13 +1511,15 @@ struct COAL_DLLAPI DistanceResult : QueryResult {
   /// @brief information about the nearest point in object 1
   /// if object 1 is mesh or point cloud, it is the triangle or point id
   /// if object 1 is geometry shape, it is NONE (-1),
-  /// if object 1 is octree, it is the id of the cell
+  /// if object 1 is octree, it is a node handle, see
+  /// @ref coal::octreeNodeHandle
   int b1;
 
   /// @brief information about the nearest point in object 2
   /// if object 2 is mesh or point cloud, it is the triangle or point id
   /// if object 2 is geometry shape, it is NONE (-1),
-  /// if object 2 is octree, it is the id of the cell
+  /// if object 2 is octree, it is a node handle, see
+  /// @ref coal::octreeNodeHandle
   int b2;
 
   /// @brief invalid contact primitive information

--- a/include/coal/internal/traversal_node_octree.h
+++ b/include/coal/internal/traversal_node_octree.h
@@ -264,8 +264,7 @@ class COAL_DLLAPI OcTreeSolver {
             &box, box_tf, &s, tf2, this->solver,
             this->drequest->enable_signed_distance, p1, p2, normal);
 
-        this->dresult->update(distance, tree1, &s,
-                              (int)(root1 - tree1->getRoot()),
+        this->dresult->update(distance, tree1, &s, octreeNodeHandle(root1),
                               DistanceResult::NONE, p1, p2, normal);
 
         return drequest->isSatisfied(*dresult);
@@ -344,10 +343,9 @@ class COAL_DLLAPI OcTreeSolver {
       if (!contactNotAdded && ncontact == 1) {
         // Update contact information.
         const Contact& c = cresult->getContact(cresult->numContacts() - 1);
-        cresult->setContact(
-            cresult->numContacts() - 1,
-            Contact(tree1, c.o2, static_cast<int>(root1 - tree1->getRoot()),
-                    c.b2, c.pos, c.normal, c.penetration_depth));
+        cresult->setContact(cresult->numContacts() - 1,
+                            Contact(tree1, c.o2, octreeNodeHandle(root1), c.b2,
+                                    c.pos, c.normal, c.penetration_depth));
       }
 
       // no need to call `internal::updateDistanceLowerBoundFromLeaf` here
@@ -399,8 +397,7 @@ class COAL_DLLAPI OcTreeSolver {
             &box, box_tf, &tri, tf2, this->solver,
             this->drequest->enable_signed_distance, p1, p2, normal);
 
-        this->dresult->update(distance, tree1, tree2,
-                              (int)(root1 - tree1->getRoot()),
+        this->dresult->update(distance, tree1, tree2, octreeNodeHandle(root1),
                               static_cast<int>(primitive_id), p1, p2, normal);
 
         return this->drequest->isSatisfied(*dresult);
@@ -531,9 +528,9 @@ class COAL_DLLAPI OcTreeSolver {
 
       if (cresult->numContacts() < crequest->num_max_contacts) {
         if (distToCollision <= crequest->collision_distance_threshold) {
-          cresult->addContact(Contact(
-              tree1, tree2, (int)(root1 - tree1->getRoot()),
-              static_cast<int>(primitive_id), c1, c2, normal, distance));
+          cresult->addContact(Contact(tree1, tree2, octreeNodeHandle(root1),
+                                      static_cast<int>(primitive_id), c1, c2,
+                                      normal, distance));
         }
       }
       return crequest->isSatisfied(*cresult);
@@ -639,9 +636,9 @@ class COAL_DLLAPI OcTreeSolver {
         if (crequest->num_max_contacts > cresult->numContacts()) {
           if (normal_top.isApprox(normal) &&
               (collision || !hfield_witness_is_on_bin_side)) {
-            cresult->addContact(
-                Contact(tree1, tree2, (int)(root1 - tree1->getRoot()),
-                        (int)Contact::NONE, c1, c2, -normal, distance));
+            cresult->addContact(Contact(tree1, tree2, octreeNodeHandle(root1),
+                                        (int)Contact::NONE, c1, c2, -normal,
+                                        distance));
           }
         }
       } else {
@@ -763,8 +760,8 @@ class COAL_DLLAPI OcTreeSolver {
           if (normal_top.isApprox(normal) &&
               (collision || !hfield_witness_is_on_bin_side)) {
             cresult->addContact(Contact(tree1, tree2, (int)Contact::NONE,
-                                        (int)(root2 - tree2->getRoot()), c1, c2,
-                                        normal, distance));
+                                        octreeNodeHandle(root2), c1, c2, normal,
+                                        distance));
           }
         }
       } else {
@@ -835,9 +832,8 @@ class COAL_DLLAPI OcTreeSolver {
             &box1, box1_tf, &box2, box2_tf, this->solver,
             this->drequest->enable_signed_distance, p1, p2, normal);
 
-        this->dresult->update(distance, tree1, tree2,
-                              (int)(root1 - tree1->getRoot()),
-                              (int)(root2 - tree2->getRoot()), p1, p2, normal);
+        this->dresult->update(distance, tree1, tree2, octreeNodeHandle(root1),
+                              octreeNodeHandle(root2), p1, p2, normal);
 
         return drequest->isSatisfied(*dresult);
       } else
@@ -934,9 +930,8 @@ class COAL_DLLAPI OcTreeSolver {
           cresult->distance_lower_bound =
               sqrt(sqrDistLowerBound) - crequest->security_margin;
         if (cresult->numContacts() < crequest->num_max_contacts)
-          cresult->addContact(
-              Contact(tree1, tree2, static_cast<int>(root1 - tree1->getRoot()),
-                      static_cast<int>(root2 - tree2->getRoot())));
+          cresult->addContact(Contact(tree1, tree2, octreeNodeHandle(root1),
+                                      octreeNodeHandle(root2)));
         return crequest->isSatisfied(*cresult);
       }
     }
@@ -976,9 +971,8 @@ class COAL_DLLAPI OcTreeSolver {
       if (this->cresult->numContacts() < this->crequest->num_max_contacts) {
         if (distToCollision <= this->crequest->collision_distance_threshold)
           this->cresult->addContact(
-              Contact(tree1, tree2, static_cast<int>(root1 - tree1->getRoot()),
-                      static_cast<int>(root2 - tree2->getRoot()), c1, c2,
-                      normal, distance));
+              Contact(tree1, tree2, octreeNodeHandle(root1),
+                      octreeNodeHandle(root2), c1, c2, normal, distance));
       }
 
       return crequest->isSatisfied(*cresult);

--- a/include/coal/octree.h
+++ b/include/coal/octree.h
@@ -40,6 +40,7 @@
 #define COAL_OCTREE_H
 
 #include <algorithm>
+#include <cstdint>
 #include <limits>
 
 #include <octomap/octomap.h>
@@ -281,6 +282,27 @@ class COAL_DLLAPI OcTree : public CollisionGeometry {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
+
+/// @brief Handle identifying an octree node, reported as `b1`/`b2` for octree
+/// contacts and distance results.
+///
+/// The handle is unique among the nodes of a tree and stays the same for as
+/// long as that node lives, which is what makes it usable as a grouping or
+/// lookup key within a query or a solve.
+///
+/// It is deliberately opaque. It is not a cell index and carries no spatial
+/// meaning, it says nothing about the order in which leaves are enumerated, and
+/// it is not reproducible: a second run, or a second tree built from the same
+/// data, yields different handles for the same cells. Use the contact position
+/// if you need to know *which* cell was touched.
+static inline int octreeNodeHandle(const OcTree::OcTreeNode* node) {
+  // Every node address is a multiple of the node's alignment, so dividing by it
+  // is injective and widens the range that survives the mask below. Clearing
+  // the sign bit keeps the handle distinguishable from Contact::NONE, which is
+  // -1.
+  const std::uintptr_t address = reinterpret_cast<std::uintptr_t>(node);
+  return static_cast<int>((address / alignof(OcTree::OcTreeNode)) & 0x7FFFFFFF);
+}
 
 /// @brief compute the bounding volume of an octree node's i-th child
 static inline void computeChildBV(const AABB& root_bv, unsigned int i,

--- a/test/octree.cpp
+++ b/test/octree.cpp
@@ -37,6 +37,8 @@
 
 #define BOOST_TEST_MODULE COAL_OCTREE
 #include <fstream>
+#include <set>
+#include <utility>
 #include <boost/test/included/unit_test.hpp>
 #include <boost/filesystem.hpp>
 
@@ -291,5 +293,146 @@ BOOST_AUTO_TEST_CASE(octree_height_field) {
       std::cout << "distance mesh box: " << dres.min_distance << std::endl;
       BOOST_CHECK(dres.min_distance < sqrt(2.) * resolution);
     }
+  }
+}
+
+// The octree side of a contact or distance result carries an opaque node
+// handle: unique per node, stable while the tree is unmodified, and never NONE.
+// It is not a cell index, so nothing here asserts a range -- what is asserted
+// is the identity contract consumers rely on, and that the other operand keeps
+// its real primitive index.
+BOOST_AUTO_TEST_CASE(octree_reports_stable_node_handle) {
+  Scalar resolution(10.);
+  std::vector<Vec3s> pEnv;
+  std::vector<Triangle32> tEnv;
+  boost::filesystem::path path(TEST_RESOURCES_DIR);
+  loadOBJFile((path / "env.obj").string().c_str(), pEnv, tEnv);
+
+  BVHModel<OBBRSS> envMesh;
+  makeMesh(pEnv, tEnv, envMesh);
+  envMesh.computeLocalAABB();
+
+  OcTree envOctree(
+      coal::loadOctreeFile((path / "env.octree").string(), resolution));
+  envOctree.computeLocalAABB();
+
+  const Transform3s tf;  // identity: the operands are guaranteed to overlap
+  CollisionRequest request(coal::CONTACT, 1000);
+
+  const CollisionGeometry* octree = &envOctree;
+
+  // Every contact must carry a handle wherever the octree sits.
+  auto collectHandles = [octree](const CollisionResult& result) {
+    BOOST_REQUIRE(result.isCollision());
+    std::vector<int> handles;
+    for (const Contact& contact : result.getContacts()) {
+      if (contact.o1 == octree) {
+        BOOST_CHECK_GE(contact.b1, 0);
+        handles.push_back(contact.b1);
+      }
+      if (contact.o2 == octree) {
+        BOOST_CHECK_GE(contact.b2, 0);
+        handles.push_back(contact.b2);
+      }
+    }
+    BOOST_CHECK(!handles.empty());
+    return handles;
+  };
+
+  // octree vs shape
+  Box box;
+  Transform3s box_tf;
+  constructBox(envOctree.aabb_local, tf, box, box_tf);
+  box.computeLocalAABB();
+  {
+    CollisionResult result1, result2;
+    coal::collide(&envOctree, tf, &box, box_tf, request, result1);
+    coal::collide(&envOctree, tf, &box, box_tf, request, result2);
+    const std::vector<int> handles = collectHandles(result1);
+    // Repeating the query must reproduce the handles exactly; that stability is
+    // the whole value of the field to a caller grouping contacts by cell.
+    BOOST_CHECK(handles == collectHandles(result2));
+    // Distinct nodes must get distinct handles. This can only be asserted where
+    // contacts are in bijection with nodes, which is the single-shape case: a
+    // mesh or height field operand yields one contact per (node, primitive), so
+    // one node legitimately recurs across several contacts there.
+    const std::set<int> distinct(handles.begin(), handles.end());
+    BOOST_CHECK_EQUAL(distinct.size(), handles.size());
+  }
+
+  // octree vs mesh: the mesh side must still carry its triangle id
+  {
+    CollisionResult result;
+    coal::collide(&envOctree, tf, &envMesh, tf, request, result);
+    collectHandles(result);
+    bool found_triangle_id = false;
+    // One node may recur here, but each (node, triangle) pair must be reported
+    // at most once.
+    std::set<std::pair<int, int> > pairs;
+    for (const Contact& contact : result.getContacts())
+      BOOST_CHECK(pairs.insert(std::make_pair(contact.b1, contact.b2)).second);
+    for (const Contact& contact : result.getContacts()) {
+      if (contact.o2 == &envMesh && contact.b2 != Contact::NONE) {
+        BOOST_CHECK_GE(contact.b2, 0);
+        BOOST_CHECK_LT(contact.b2, (int)envMesh.num_tris);
+        found_triangle_id = true;
+      }
+    }
+    BOOST_CHECK(found_triangle_id);
+  }
+
+  // octree vs octree: both sides are the same octree, so both carry handles
+  {
+    CollisionResult result;
+    coal::collide(&envOctree, tf, &envOctree, tf, request, result);
+    collectHandles(result);
+  }
+
+  // octree vs height field, both operand orders: the handle must follow the
+  // octree across the swap rather than staying on one side.
+  const AABB& octree_aabb = envOctree.aabb_local;
+  const MatrixXs heights =
+      MatrixXs::Constant(100, 100, octree_aabb.max_[2] + Scalar(1));
+  HeightField<AABB> hfield(octree_aabb.max_[0] - octree_aabb.min_[0],
+                           octree_aabb.max_[1] - octree_aabb.min_[1], heights,
+                           octree_aabb.min_[2] - Scalar(1));
+  hfield.computeLocalAABB();
+  // Centre the field on the octree in XY; it already spans the octree in Z.
+  Transform3s hfield_tf;
+  hfield_tf.setTranslation(Vec3s(
+      Scalar(0.5) * (octree_aabb.min_[0] + octree_aabb.max_[0]),
+      Scalar(0.5) * (octree_aabb.min_[1] + octree_aabb.max_[1]), Scalar(0)));
+  {
+    CollisionResult result1, result2;
+    coal::collide(&envOctree, tf, &hfield, hfield_tf, request, result1);
+    coal::collide(&hfield, hfield_tf, &envOctree, tf, request, result2);
+    collectHandles(result1);
+    collectHandles(result2);
+  }
+
+  // A distance result takes b1/b2 from the closest leaf pair and owes the same
+  // contract. Height fields are absent because octree/height-field distance is
+  // not implemented.
+  {
+    const DistanceRequest dreq;
+    DistanceResult dres;
+
+    coal::distance(&envOctree, tf, &box, box_tf, dreq, dres);
+    BOOST_CHECK(dres.o1 == octree);
+    BOOST_CHECK_GE(dres.b1, 0);
+    BOOST_CHECK(dres.b2 == DistanceResult::NONE);
+
+    dres.clear();
+    coal::distance(&envOctree, tf, &envMesh, tf, dreq, dres);
+    BOOST_CHECK(dres.o1 == octree);
+    BOOST_CHECK_GE(dres.b1, 0);
+    // The mesh side must still carry its triangle id.
+    BOOST_CHECK_GE(dres.b2, 0);
+    BOOST_CHECK_LT(dres.b2, (int)envMesh.num_tris);
+
+    dres.clear();
+    coal::distance(&envOctree, tf, &envOctree, tf, dreq, dres);
+    BOOST_CHECK_GE(dres.b1, 0);
+    BOOST_CHECK_GE(dres.b2, 0);
   }
 }


### PR DESCRIPTION
## The problem

The octree side of a contact reported `b1`/`b2` as

```cpp
Contact(tree1, c.o2, static_cast<int>(root1 - tree1->getRoot()), c.b2, ...)
```

`root1` and the tree root are separate heap allocations, not elements of one array, so this pointer subtraction is undefined behaviour. AddressSanitizer's invalid-pointer-pair check reports it directly on real octomap data:

```
==22==ERROR: AddressSanitizer: invalid-pointer-pair: 0x502000000470 0x502000000010
    #0 in main probe.cpp:13
0x502000000470 is located 0 bytes inside of 16-byte region [0x502000000470,0x502000000480)
allocated by thread T0 here:
    #0 operator new(unsigned long)
    #1 (/lib/x86_64-linux-gnu/liboctomap.so.1.9+0x19058)
```

(built with `-fsanitize=address,pointer-subtract`, run with `ASAN_OPTIONS=detect_invalid_pointer_pairs=2`).

Two properties make the result unusable beyond the formal problem. Pointer subtraction is **scaled** — `p - q` is `(byte difference) / sizeof(T)` — so it is an element count for an array these nodes were never in. And it is **signed**: a node below the root gives a negative value, and one exactly a node-width below gives `-1`, which is indistinguishable from the sentinel meaning "no index". Consumers reading `b1` for an octree contact got a value that changed between runs of the same binary on the same data.

## Why a handle, and not an index

This field carries node *identity* on the octree path, and always has. Until the result types were unified onto the generic `Contact`, octree traversals returned a dedicated struct holding the node itself:

```cpp
struct OcTreeShapeCollisionPair
{
  /** \brief The pointer to the octree node */
  const OcTree::OcTreeNode* node;
  ...
};
```

`c90f59ef` (2012-07-25) replaced that with `Contact`, whose `b1`/`b2` are `int`. A pointer no longer fit, and `root1 - tree1->getRoot()` is how it was made to fit. So the value has never been a cell index — the `b1`/`b2` documentation claiming "the id of the cell" has been aspirational since then — and callers that group contacts per cell depend on the identity it does carry.

`coal::octreeNodeHandle` keeps that identity and makes it well defined:

- `reinterpret_cast<std::uintptr_t>` is implementation-defined, not undefined;
- dividing by `alignof` rather than `sizeof` makes the mapping injective by rule, since every address is a multiple of its alignment — the old expression was injective only because the allocator happens to over-align 16-byte nodes;
- clearing the sign bit keeps the handle disjoint from the no-index sentinel, so the `-1` case above cannot recur.

Two nodes collide only if they lie 16 GiB apart in memory. On the test octree all 1385421 occupied leaves receive distinct handles.

The handle is documented as opaque: not a cell index, no spatial or enumeration meaning, and not reproducible across processes. Use the contact position if you need to know which cell was touched.

## Changes

- All 12 sites report `octreeNodeHandle` where the pointer difference was, across the shape, mesh, octree and height field traversals and their distance variants. The other operand's real primitive index — a mesh triangle id — is untouched, as is the sentinel on the height field side.
- `b1`/`b2` documentation in `collision_data.h` updated on all four fields.
- `octree_reports_stable_node_handle` in `test/octree.cpp` covers every traversal that can produce an octree contact: handles are never negative, and so never the sentinel, repeating a query reproduces them exactly, and they are distinct per node where contacts are in bijection with nodes. A mesh operand keeps its triangle id and each `(node, triangle)` pair is reported once. Both operand orders are exercised for the height field, since the handle has to follow the octree across the swap.
- The same case covers the distance path, which reaches these sites through `DistanceResult::update`: the octree against a shape, against a mesh, and against itself. The shape side reports the sentinel and the mesh side its triangle id. Height fields are absent there because octree/height-field distance is not implemented.

## Verification

Full suite green (36/36). The new test fails against the previous expression, as it should.

