### PR TITLE
nix: update eigenpy cache

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4,15 +4,14 @@
       "inputs": {
         "gepetto": [
           "gepetto"
-        ],
-        "jrl-cmakemodules": "jrl-cmakemodules"
+        ]
       },
       "locked": {
-        "lastModified": 1782893948,
-        "narHash": "sha256-W6rihqLGgj9SawoHRd68Rxql958KYVlqbGH2RnzQIBE=",
+        "lastModified": 1787778216,
+        "narHash": "sha256-IdpvbbhgEc4f7A4DOV7/7EUhikULQijQnvBKqb3K4Gc=",
         "owner": "stack-of-tasks",
         "repo": "eigenpy",
-        "rev": "181c92e341896db5824b1c7062fd762b5fcc8904",
+        "rev": "bf42033f1c34d4b524482b1f03b3dbf47688dc48",
         "type": "github"
       },
       "original": {
@@ -42,11 +41,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -118,11 +117,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782042109,
-        "narHash": "sha256-oDCl/rcvJVTcf6G2ag3YdZSMHDVBBmoXTysY5yzq+Dk=",
+        "lastModified": 1787681867,
+        "narHash": "sha256-EDS+athZryaXoyyaSGx2CAFubiHjBBv091aO7fWmsQs=",
         "owner": "gepetto",
         "repo": "flakoboros",
-        "rev": "fc7d44063fa05f1a78c97c63b124c1da2862331c",
+        "rev": "c9263824f07efad4ca8c158c70b0314866bbb4e8",
         "type": "github"
       },
       "original": {
@@ -152,8 +151,6 @@
           "flakoboros",
           "nixpkgs"
         ],
-        "pyproject-build-systems": "pyproject-build-systems",
-        "pyproject-nix": "pyproject-nix",
         "rosdistro": [
           "gepetto",
           "gazebros2nix",
@@ -171,15 +168,14 @@
           "gazebros2nix",
           "flakoboros",
           "treefmt-nix"
-        ],
-        "uv2nix": "uv2nix"
+        ]
       },
       "locked": {
-        "lastModified": 1782566589,
-        "narHash": "sha256-vXVLP31bnnk8KUBUV88Ms2R6P06wdQPZzsXgR6iZ5FI=",
+        "lastModified": 1787690521,
+        "narHash": "sha256-uFx+F0eEMLfMVB/2ZLioVsf1S6lLqVkPOVt0HvfWjlQ=",
         "owner": "gepetto",
         "repo": "gazebros2nix",
-        "rev": "6e51068e9e9fec8e960f68911127ad64b417bf6b",
+        "rev": "9b81b5a9e2d5230dbf43c50393326e4b8739dbcd",
         "type": "github"
       },
       "original": {
@@ -213,6 +209,7 @@
           "gazebros2nix",
           "nixpkgs"
         ],
+        "nixpkgs-update": "nixpkgs-update",
         "system-manager": "system-manager",
         "systems": [
           "gepetto",
@@ -226,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782843986,
-        "narHash": "sha256-YxzK+K/Zzw24cV6uaVsLDMTLDpONz0bZRSXW7HVW3HA=",
+        "lastModified": 1787692369,
+        "narHash": "sha256-Xvhto3lMELQkUKz30SLsoa6Hl1L/1F9rqJ9qO8TXBZY=",
         "owner": "gepetto",
         "repo": "nix",
-        "rev": "bb788a93d4d821772070fd5ab40491cef0910a5b",
+        "rev": "642b1a339f0d9a9d2457c15a5e31cf19d51f1f14",
         "type": "github"
       },
       "original": {
@@ -267,42 +264,20 @@
       "inputs": {
         "nixpkgs": [
           "gepetto",
-          "nixpkgs"
+          "nixpkgs-update"
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1787680808,
+        "narHash": "sha256-9168tNt0NZdtlx5RM5huEuc9NCWMLACJA9O4UK/l2Zc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "6840c9a8f50722944eb106ce8bb237c138584f2a",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
         "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "jrl-cmakemodules": {
-      "inputs": {
-        "gepetto": [
-          "eigenpy",
-          "gepetto"
-        ]
-      },
-      "locked": {
-        "lastModified": 1782767220,
-        "narHash": "sha256-CCLmZFYX0fU/r9+I3eLTUlvyXCzqkWExrAa6EaUzmM0=",
-        "owner": "jrl-umi3218",
-        "repo": "jrl-cmakemodules",
-        "rev": "2bffcade6e002e60428014f5e0658583711b4253",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jrl-umi3218",
-        "repo": "jrl-cmakemodules",
         "type": "github"
       }
     },
@@ -313,11 +288,11 @@
         "rosdistro": "rosdistro"
       },
       "locked": {
-        "lastModified": 1781900693,
-        "narHash": "sha256-4KFk+S9ZbMonItYsdPtZjwESsgrCEpXGDa6rosDxLGs=",
+        "lastModified": 1787294587,
+        "narHash": "sha256-chIbMlZqzwOyd4SJicJmHG3xmaUlC+7ZQ58yXHXWTrI=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "fb296510db68c2e760980ab8c6daf6ded9060213",
+        "rev": "9c3b7c38f1084cfff014c41f304d22a618d1def9",
         "type": "github"
       },
       "original": {
@@ -331,7 +306,7 @@
       "inputs": {
         "nixpkgs": [
           "gepetto",
-          "nixpkgs"
+          "nixpkgs-update"
         ]
       },
       "locked": {
@@ -350,11 +325,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
         "type": "github"
       },
       "original": {
@@ -366,16 +341,32 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-update": {
+      "locked": {
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -409,78 +400,20 @@
         "type": "github"
       }
     },
-    "pyproject-build-systems": {
-      "inputs": {
-        "nixpkgs": [
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "gepetto",
-          "gazebros2nix",
-          "pyproject-nix"
-        ],
-        "uv2nix": [
-          "gepetto",
-          "gazebros2nix",
-          "uv2nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1782093830,
-        "narHash": "sha256-6gmEVe69+KlRkZD4PEEV5xAlB9CB0Y9TiuEgQjDrKTQ=",
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "rev": "430680a19bc85a3bda55f12e4cc1a1aadcf2e478",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "type": "github"
-      }
-    },
-    "pyproject-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1782089418,
-        "narHash": "sha256-LRD1SuQWr49fGq3A+8GLXfsLE2xqIpQA440YDZwms3M=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "43f0b40edd0a74c63f66b7b48d969ae6b740d611",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "eigenpy": "eigenpy",
-        "gepetto": "gepetto",
-        "jrl-cmakemodules": [
-          "eigenpy",
-          "jrl-cmakemodules"
-        ]
+        "gepetto": "gepetto"
       }
     },
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1781238695,
-        "narHash": "sha256-Sk8KQa9ryFrkdGGZ64sNdqoVqiGmC+IAAi3qzE7zn8s=",
+        "lastModified": 1786735438,
+        "narHash": "sha256-rxCA2+gTQYkpngm9cY3s9gTNtStPbzlts0U3HuTtarg=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "a0e7ccc6f866a081acc0656d9cd03cda7acc6853",
+        "rev": "b045bb798698b128867db5a3a81e515ecf32d38e",
         "type": "github"
       },
       "original": {
@@ -494,16 +427,16 @@
         "flake-compat": "flake-compat",
         "nixpkgs": [
           "gepetto",
-          "nixpkgs"
+          "nixpkgs-update"
         ],
         "userborn": "userborn"
       },
       "locked": {
-        "lastModified": 1778508009,
-        "narHash": "sha256-mp63mt+EwfKiVZX+4BC/59g5oTbsXNtSYESVci3opso=",
+        "lastModified": 1786747314,
+        "narHash": "sha256-L8GneKBeYOStPrLUAypI8bDGNjntcH2AngxSig/ul8c=",
         "owner": "numtide",
         "repo": "system-manager",
-        "rev": "dc1baae12eed1758755e73f8aff7fca5502c6e9f",
+        "rev": "64748b62d6ae74c069234103ce368626bcad8c70",
         "type": "github"
       },
       "original": {
@@ -552,11 +485,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {
@@ -593,33 +526,6 @@
         "owner": "jfroche",
         "ref": "system-manager",
         "repo": "userborn",
-        "type": "github"
-      }
-    },
-    "uv2nix": {
-      "inputs": {
-        "nixpkgs": [
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "gepetto",
-          "gazebros2nix",
-          "pyproject-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781810314,
-        "narHash": "sha256-PQfvfKWaBvCysdHFUO5GewwvwIqI/WL6OcrJhDSUdbc=",
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "rev": "14aa44100859a44144878fe079f8089d3fa4dc4e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,9 @@
   inputs = {
     gepetto.url = "github:gepetto/nix";
 
-    # eigenpy v3.12.0 does not handle eigen v5, so we need devel for now
+    # use eigenpy build against eigen 5 from cache
     eigenpy.url = "github:stack-of-tasks/eigenpy";
     eigenpy.inputs.gepetto.follows = "gepetto";
-    jrl-cmakemodules.follows = "eigenpy/jrl-cmakemodules";
   };
 
   outputs =
@@ -15,10 +14,7 @@
     inputs.gepetto.lib.mkFlakoboros inputs (
       { lib, ... }:
       {
-        overlays = [
-          inputs.jrl-cmakemodules.overlays.flakoboros
-          inputs.eigenpy.overlays.flakoboros
-        ];
+        overlays = [ inputs.eigenpy.overlays.flakoboros ];
         extraDevPyPackages = [ "coal" ];
         overrideAttrs.coal =
           { drv-prev, ... }:


### PR DESCRIPTION
Follows https://github.com/stack-of-tasks/eigenpy/pull/662

Flake lock file updates:
```
• Updated input 'eigenpy':
    'github:stack-of-tasks/eigenpy/181c92e341896db5824b1c7062fd762b5fcc8904?narHash=sha256-W6rihqLGgj9SawoHRd68Rxql958KYVlqbGH2RnzQIBE%3D' (2026-07-01)
  → 'github:stack-of-tasks/eigenpy/bf42033f1c34d4b524482b1f03b3dbf47688dc48?narHash=sha256-IdpvbbhgEc4f7A4DOV7/7EUhikULQijQnvBKqb3K4Gc%3D' (2026-08-26)
• Removed input 'eigenpy/jrl-cmakemodules'
• Removed input 'eigenpy/jrl-cmakemodules/gepetto' • Updated input 'gepetto':
    'github:gepetto/nix/bb788a93d4d821772070fd5ab40491cef0910a5b?narHash=sha256-YxzK%2BK/Zzw24cV6uaVsLDMTLDpONz0bZRSXW7HVW3HA%3D' (2026-06-30)
  → 'github:gepetto/nix/642b1a339f0d9a9d2457c15a5e31cf19d51f1f14?narHash=sha256-Xvhto3lMELQkUKz30SLsoa6Hl1L/1F9rqJ9qO8TXBZY%3D' (2026-08-25)
• Updated input 'gepetto/gazebros2nix':
    'github:gepetto/gazebros2nix/6e51068e9e9fec8e960f68911127ad64b417bf6b?narHash=sha256-vXVLP31bnnk8KUBUV88Ms2R6P06wdQPZzsXgR6iZ5FI%3D' (2026-06-27)
  → 'github:gepetto/gazebros2nix/9b81b5a9e2d5230dbf43c50393326e4b8739dbcd?narHash=sha256-uFx%2BF0eEMLfMVB/2ZLioVsf1S6lLqVkPOVt0HvfWjlQ%3D' (2026-08-25)
• Updated input 'gepetto/gazebros2nix/flakoboros':
    'github:gepetto/flakoboros/fc7d44063fa05f1a78c97c63b124c1da2862331c?narHash=sha256-oDCl/rcvJVTcf6G2ag3YdZSMHDVBBmoXTysY5yzq%2BDk%3D' (2026-06-21)
  → 'github:gepetto/flakoboros/c9263824f07efad4ca8c158c70b0314866bbb4e8?narHash=sha256-EDS%2BathZryaXoyyaSGx2CAFubiHjBBv091aO7fWmsQs%3D' (2026-08-25)
• Updated input 'gepetto/gazebros2nix/flakoboros/flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb?narHash=sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4%3D' (2026-05-13)
  → 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a?narHash=sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw%3D' (2026-08-01)
• Updated input 'gepetto/gazebros2nix/flakoboros/flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/f5901329dade4a6ea039af1433fb087bd9c1fe14?narHash=sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ%3D' (2026-04-26)
  → 'github:nix-community/nixpkgs.lib/0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c?narHash=sha256-OmshNvn2vupOFpYinLUu%2B1Dnpu4n7Q5N3ggGVNHpkUI%3D' (2026-07-26)
• Updated input 'gepetto/gazebros2nix/flakoboros/nix-ros-overlay':
    'github:lopsided98/nix-ros-overlay/fb296510db68c2e760980ab8c6daf6ded9060213?narHash=sha256-4KFk%2BS9ZbMonItYsdPtZjwESsgrCEpXGDa6rosDxLGs%3D' (2026-06-19)
  → 'github:lopsided98/nix-ros-overlay/9c3b7c38f1084cfff014c41f304d22a618d1def9?narHash=sha256-chIbMlZqzwOyd4SJicJmHG3xmaUlC%2B7ZQ58yXHXWTrI%3D' (2026-08-21)
• Updated input 'gepetto/gazebros2nix/flakoboros/nix-ros-overlay/nixpkgs':
    'github:NixOS/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb?narHash=sha256-30sZNZoA1cqF5JNO9fVX%2BwgiQYjB7HJqqJ4ztCDeBZE%3D' (2026-05-15)
  → 'github:NixOS/nixpkgs/e72e4f299401a3689d4b3d5fc6496b11db7064eb?narHash=sha256-8fsyqeO%2BmJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs%3D' (2026-08-04)
• Updated input 'gepetto/gazebros2nix/flakoboros/nix-ros-overlay/rosdistro':
    'github:ros/rosdistro/a0e7ccc6f866a081acc0656d9cd03cda7acc6853?narHash=sha256-Sk8KQa9ryFrkdGGZ64sNdqoVqiGmC%2BIAAi3qzE7zn8s%3D' (2026-06-12)
  → 'github:ros/rosdistro/b045bb798698b128867db5a3a81e515ecf32d38e?narHash=sha256-rxCA2%2BgTQYkpngm9cY3s9gTNtStPbzlts0U3HuTtarg%3D' (2026-08-14)
• Updated input 'gepetto/gazebros2nix/flakoboros/treefmt-nix':
    'github:numtide/treefmt-nix/db947814a175b7ca6ded66e21383d938df01c227?narHash=sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM%3D' (2026-05-31)
  → 'github:numtide/treefmt-nix/27b3b12a8e6375f28ebe122f07d230ca5459bbfa?narHash=sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE%3D' (2026-08-16)
• Removed input 'gepetto/gazebros2nix/pyproject-build-systems' • Removed input 'gepetto/gazebros2nix/pyproject-build-systems/nixpkgs' • Removed input 'gepetto/gazebros2nix/pyproject-build-systems/pyproject-nix' • Removed input 'gepetto/gazebros2nix/pyproject-build-systems/uv2nix' • Removed input 'gepetto/gazebros2nix/pyproject-nix' • Removed input 'gepetto/gazebros2nix/pyproject-nix/nixpkgs' • Removed input 'gepetto/gazebros2nix/uv2nix'
• Removed input 'gepetto/gazebros2nix/uv2nix/nixpkgs' • Removed input 'gepetto/gazebros2nix/uv2nix/pyproject-nix' • Updated input 'gepetto/home-manager':
    'github:nix-community/home-manager/3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f?narHash=sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0%3D' (2026-05-23)
  → 'github:nix-community/home-manager/6840c9a8f50722944eb106ce8bb237c138584f2a?narHash=sha256-9168tNt0NZdtlx5RM5huEuc9NCWMLACJA9O4UK/l2Zc%3D' (2026-08-25)
• Updated input 'gepetto/home-manager/nixpkgs':
    follows 'gepetto/nixpkgs'
  → follows 'gepetto/nixpkgs-update'
• Updated input 'gepetto/nix-system-graphics/nixpkgs':
    follows 'gepetto/nixpkgs'
  → follows 'gepetto/nixpkgs-update'
• Added input 'gepetto/nixpkgs-update':
    'github:NixOS/nixpkgs/56c02bc00adcf003215cc4bd996d6efaf4cff188?narHash=sha256-9i/VTdusq/%2BNM/tz%2BJ1Re%2BojkMB8MBf0QshnYfzHz30%3D' (2026-08-23)
• Updated input 'gepetto/system-manager':
    'github:numtide/system-manager/dc1baae12eed1758755e73f8aff7fca5502c6e9f?narHash=sha256-mp63mt%2BEwfKiVZX%2B4BC/59g5oTbsXNtSYESVci3opso%3D' (2026-05-11)
  → 'github:numtide/system-manager/64748b62d6ae74c069234103ce368626bcad8c70?narHash=sha256-L8GneKBeYOStPrLUAypI8bDGNjntcH2AngxSig/ul8c%3D' (2026-08-14)
• Updated input 'gepetto/system-manager/nixpkgs':
    follows 'gepetto/nixpkgs'
  → follows 'gepetto/nixpkgs-update'
• Removed input 'jrl-cmakemodules'
```