### PR TITLE
Close the unbalanced diagnostic push in narrowphase.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Python 3.10 is the minimal supported Python version
 - Nix: switch to flakoboros ([#852](https://github.com/coal-library/coal/pull/852))
 - Allow to use Python variant in pixi build ([#872](https://github.com/coal-library/coal/pull/872))
+- Close the unbalanced diagnostic push in `narrowphase.h`, which disabled warnings for the rest of every downstream translation unit ([#890](https://github.com/coal-library/coal/pull/890))
 
 ## [3.0.4] - 2026-06-29
 

--- a/include/coal/narrowphase/narrowphase.h
+++ b/include/coal/narrowphase/narrowphase.h
@@ -135,6 +135,7 @@ struct COAL_DLLAPI GJKSolver {
         epa(0, EPA_DEFAULT_TOLERANCE),
         epa_max_iterations(EPA_DEFAULT_MAX_ITERATIONS),
         epa_tolerance(EPA_DEFAULT_TOLERANCE) {}
+  COAL_COMPILER_DIAGNOSTIC_POP
 
   /// @brief Constructor from a DistanceRequest
   ///


### PR DESCRIPTION
## The problem

`include/coal/narrowphase/narrowphase.h` opens **three** `COAL_COMPILER_DIAGNOSTIC_PUSH` (around the `GJKSolver` default constructor, `operator==`, and one further down) but closes only **two**. The push wrapping the default constructor is never popped.

Because a diagnostic push is a property of the preprocessed token stream rather than of the file, that unbalanced push escapes the header. It then swallows the *next* `#pragma GCC diagnostic pop` in the translation unit — which, for a downstream project, is typically its own pop closing the suppression it wraps around its third-party includes. The result is that the consumer's warning suppression never ends, and the warnings it names stay disabled for the remainder of every translation unit that includes coal.

In our case (`tesseract_collision_coal`) that silently disabled `-Wall`, `-Wunused-parameter`, `-Wconversion` and `-Wsign-conversion` for the whole plugin, despite `-Werror=` for all four being on the command line. A canary appended after the includes — unused parameter, narrowing conversion, signed→unsigned — compiled with exit 0 and no diagnostics; the identical canary standalone errors on two of them.

## Why it is easy to miss

A per-file audit reports every file involved as balanced, because each one *is* internally balanced — the imbalance only exists once the stream is assembled. It shows up by measuring net push/pop per file over the preprocessed output:

```
gcc -E <flags> file.cpp | awk '/^# [0-9]+ "/{f=$3} /diagnostic push/{n[f]++} /diagnostic pop/{n[f]--} END{for(k in n) if(n[k]) print n[k], k}'
```

which reports `narrowphase.h +1`. (Eigen's `DisableStupidWarnings.h` `+8` / `ReenableStupidWarnings.h` `-8` and boost's `header.hpp` / `footer.hpp` pairs also appear — those are by design and net zero across their file pairs.)

Worth noting the attribution is counter-intuitive: tracking "which push was open when the depth stopped returning to zero" names the outermost *innocent* push in the consumer's own header, and sends you to the wrong repository. Per-file net is what points here.

## The change

One line: the matching `COAL_COMPILER_DIAGNOSTIC_POP` after the default constructor, following the shape the two balanced blocks in the same file already use — push, ignore, one member, pop. Nothing else changes; the ignore still covers exactly the constructor it was meant to cover.

I have not touched the `IGNORED_DEPRECECATED_DECLARATIONS` spelling, since renaming a public macro is a separate call for you to make.